### PR TITLE
Add Claude auto PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,113 @@
+name: Claude PR Review - Auto
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+
+concurrency:
+  group: claude-auto-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: '!github.event.pull_request.draft'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create MCP config
+        run: |
+          cat > /tmp/mcp-config.json << 'EOF'
+          {
+            "mcpServers": {
+              "github": {
+                "type": "http",
+                "url": "https://api.githubcopilot.com/mcp/",
+                "headers": {
+                  "Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"
+                }
+              },
+              "context7": {
+                "type": "http",
+                "url": "https://mcp.context7.com/mcp"
+              }
+            }
+          }
+          EOF
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Auto-review PRs pushed by claude[bot] (the actor agent-authored
+          # branches push under) too. Without the bot in this list the action
+          # hard-fails with "Workflow initiated by non-human actor" instead of
+          # reviewing. A posted review is not a push/synchronize event, so this
+          # can't loop.
+          allowed_bots: 'claude[bot]'
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR TITLE: ${{ github.event.pull_request.title }}
+            PR DESCRIPTION: ${{ github.event.pull_request.body }}
+            PR AUTHOR: ${{ github.event.pull_request.user.login }}
+
+            This repo is doc-structure-lint: a Node.js ESM CLI/library that validates
+            Markdown and AsciiDoc structure against YAML/JSON templates. Source lives in
+            `src/` (parsers, rules validators, template loading, utils); tests are
+            colocated `*.test.js` files run with mocha + chai.
+
+            Perform a thorough code review of this pull request. Focus areas:
+
+            Correctness & completeness
+            - Obvious bugs, logic errors, or areas with complex logic needing extra scrutiny
+            - Unfinished work, incomplete implementations, or low-quality code
+            - Breaking changes to the CLI interface, exported API, or template schema
+            - Missing error handling at system boundaries (file I/O, network fetches, parsing, model loading)
+
+            Code quality
+            - Consistency with existing codebase style, architecture, and patterns
+            - Readability and maintainability (naming, organization)
+            - DRY — flag duplicate/one-off code that should use existing utilities (or create reusable ones)
+            - Correct ESM usage (this package is `"type": "module"`), and validator modules
+              that follow the shared rules/ValidationError conventions
+
+            Security
+            - Path traversal and unsafe file access when resolving user-supplied file or template paths
+            - Untrusted input handling: remote template/file URLs, `$ref` resolution, YAML/JSON parsing
+            - Command injection or unsafe shell/child-process usage
+            - Secrets or credentials leaking into logs, temp files, or committed fixtures
+
+            Testing & observability
+            - Test coverage for new logic — flag untested paths in `src/**/*.test.js`
+            - Missing or unclear error messages for failures users are expected to act on
+
+            Keep feedback concise. Use suggested fixes where possible.
+
+            You MUST submit a proper GitHub Pull Request Review (not loose line comments). Flow:
+            1. mcp__github__get_pull_request_diff — load exact changed lines before commenting.
+            2. mcp__github__create_pending_pull_request_review — start a pending review.
+            3. mcp__github__add_pull_request_review_comment_to_pending_review — one call per specific-line issue, targeting a line present in the diff.
+            4. mcp__github__submit_pending_pull_request_review — submit with event = APPROVE, REQUEST_CHANGES, or COMMENT.
+
+            The review body is your summary comment. Structure it as:
+              - One-line verdict with reasoning.
+              - Issues grouped by severity: **Blocking**, **Important**, **Nit**. Each entry: short description + file:line link.
+              - If no issues: confirm PR looks good.
+
+            Prefer the pending-review flow over create_issue_comment / inline_comment tools — we want a single cohesive review on the PR, not scattered comments.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 50
+            --mcp-config /tmp/mcp-config.json
+            --allowedTools "Bash(git diff:*),Bash(git log:*),Read,Glob,mcp__github__get_pull_request_diff,mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_issue_comments,mcp__context7__resolve-library-id,mcp__context7__query-docs"


### PR DESCRIPTION
Ports the Claude PR review workflow from `doc-detective` into this repo.

## What it does

On every non-draft PR (`opened`, `ready_for_review`, `reopened`, `synchronize`), Claude loads the diff and submits a single cohesive GitHub Pull Request Review — issues grouped as **Blocking** / **Important** / **Nit**, with inline comments on the changed lines. Per-PR concurrency cancels superseded runs.

## Adapted from the source

- `allowed_bots` trimmed to `claude[bot]` — no Promptless in this repo, so its `@Promptless` trigger block is dropped.
- Added a repo-orientation preamble (ESM CLI/library, `src/` layout, colocated mocha tests).
- Review focus areas retargeted off the TypeScript/Supabase stack:
  - API/DB-schema breakage → CLI / exported API / template schema breakage
  - TypeScript type safety → ESM conventions and shared `rules/ValidationError` patterns
  - Supabase RLS, SQL injection, XSS → path traversal on user-supplied paths, untrusted remote templates and `$ref` resolution, command injection, secret leakage into temp files and fixtures
  - logs/metrics/alerts → actionable error messages

Unchanged: trigger set, MCP config (GitHub + Context7), `track_progress`, the pending-review flow, and `claude_args` (sonnet-4-6, 50 turns, same tool allowlist).

## Before this does anything

Needs a `CLAUDE_CODE_OAUTH_TOKEN` repository secret. Without it the job runs and fails at the action step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request reviews for eligible, non-draft pull requests.
  * Reviews assess correctness, code quality, security, and test coverage.
  * Review results are submitted directly to the pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->