### PR TITLE
chore(lint): adopt the Moose Vale package

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "extraKnownMarketplaces": {
+    "agent-tools": {
+      "source": { "source": "github", "repo": "vale-cli/agent-tools" }
+    }
+  },
+  "enabledPlugins": {
+    "vale@agent-tools": true
+  }
+}

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,0 +1,29 @@
+name: Vale
+
+# Prose lint against the Moose house voice (Voices + Direct). Advisory for
+# now: reviewdog annotates only the lines a PR adds, and errors do not fail
+# the check. Flip fail_on_error once the existing corpus is worked down.
+on:
+  pull_request:
+    paths:
+      - "**.md"
+      - "**.mdx"
+      - ".vale.ini"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  vale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: vale-cli/vale-action@v3
+        with:
+          version: 3.20.0
+          reporter: github-pr-review
+          filter_mode: added
+          fail_on_error: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist/
 
 # Vitest cache
 .vitest/
+
+# Vale styles are fetched by `vale sync`, not committed
+.vale/styles/

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,8 @@
+# House voice for every document in this repo. The Moose package enables the
+# Voices core, the Direct voice, and the Moose house rules for all Markdown
+# and text files. No section exemptions: README, ADRs, CLAUDE.md, and the
+# docs site are all held to the same voice.
+# Package source: https://github.com/hawkeyexl/moose-vale
+StylesPath = .vale/styles
+MinAlertLevel = suggestion
+Packages = https://github.com/hawkeyexl/moose-vale/releases/latest/download/Moose.zip


### PR DESCRIPTION
## Summary

- Adds a root `.vale.ini` that pulls the shared **Moose** Vale package (https://github.com/hawkeyexl/moose-vale): the Voices core, the **Direct** voice (no hedging, no preamble, sentences under 25 words), and the Moose house rules, for every Markdown and text file in the repo.
- Adds `.github/workflows/vale.yml`: `vale-cli/vale-action` v3 on Vale 3.20.0, reporting through reviewdog as PR review comments. Advisory for now: only added lines are annotated and errors do not fail the check.
- Gitignores `.vale/styles/`; `vale sync` fetches them.

## Baseline

`vale .` on `main` today: 270 alerts across 13 files, mostly `Direct.Length` and `Moose.EmDash`. Nothing fails. New prose gets annotated as it lands, and the backlog can be worked down before `fail_on_error` is flipped.

## Docs impact

None. Lint configuration only; no user-facing behavior changes, so no ADR.

## Local use

```bash
vale sync
vale .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added automated prose linting for Markdown and MDX pull requests using the project’s house writing style.
  * Added consistent documentation guidance to help maintain a clear, unified voice.
  * Lint feedback highlights newly added lines and remains advisory, so it does not block pull requests.
* **Chores**
  * Added supporting configuration for maintaining and updating the documentation style rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->