### PR TITLE
chore(lint): work the Vale corpus to zero and gate on it

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,8 +1,13 @@
 name: Vale
 
-# Prose lint against the Moose house voice (Voices + Direct). Advisory for
-# now: reviewdog annotates only the lines a PR adds, and errors do not fail
-# the check. Flip fail_on_error once the existing corpus is worked down.
+# Prose lint against the Moose house voice (Voices + Direct). This is a gate:
+# the corpus is clean, so reviewdog checks every file rather than only the
+# lines a pull request adds, and any alert fails the check. Checking the whole
+# corpus is what catches a change that breaks the voice in a file it did not
+# touch, such as an edit to `.vale.ini`.
+#
+# Test fixtures and sample artifacts are exempted in `.vale.ini`, not here, so
+# a local `vale .` and this job see the same files.
 on:
   pull_request:
     paths:
@@ -18,12 +23,18 @@ jobs:
   vale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # The action runs `vale sync` for the package named in `.vale.ini`.
+      # An unsynced package is a hard Vale error rather than a silent pass,
+      # so a failure to fetch it cannot leave this job green over nothing.
       - uses: vale-cli/vale-action@v3
         with:
           version: 3.20.0
           reporter: github-pr-review
-          filter_mode: added
-          fail_on_error: false
+          filter_mode: nofilter
+          fail_on_error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -2,9 +2,13 @@ name: Vale
 
 # Prose lint against the Moose house voice (Voices + Direct). This is a gate:
 # the corpus is clean, so reviewdog checks every file rather than only the
-# lines a pull request adds, and any alert fails the check. Checking the whole
-# corpus is what catches a change that breaks the voice in a file it did not
-# touch, such as an edit to `.vale.ini`.
+# lines a pull request adds, and any alert at any severity fails the check.
+# Checking the whole corpus is what catches a change that breaks the voice in
+# a file it did not touch, such as an edit to `.vale.ini`.
+#
+# `fail_level: any` rather than `fail_on_error: true`: the latter maps to
+# reviewdog's `-fail-level=error`, which passes the one warning-level rule the
+# package ships (`Voices.ColonReveal`). `fail_level` takes precedence over it.
 #
 # Test fixtures and sample artifacts are exempted in `.vale.ini`, not here, so
 # a local `vale .` and this job see the same files.
@@ -13,11 +17,19 @@ on:
     paths:
       - "**.md"
       - "**.mdx"
+      # The package styles `*.{md,mdx,txt}`, so `.txt` is gated too.
+      - "**.txt"
       - ".vale.ini"
+      # So a change to the gate itself runs the gate.
+      - ".github/workflows/vale.yml"
 
 permissions:
   contents: read
   pull-requests: write
+
+concurrency:
+  group: vale-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   vale:
@@ -27,14 +39,23 @@ jobs:
         with:
           persist-credentials: false
 
-      # The action runs `vale sync` for the package named in `.vale.ini`.
-      # An unsynced package is a hard Vale error rather than a silent pass,
-      # so a failure to fetch it cannot leave this job green over nothing.
+      # The action runs `vale sync` and throws if the package cannot be
+      # fetched. That throw is the only thing standing between a failed fetch
+      # and a green run: every `BasedOnStyles` lives inside the package, so
+      # Vale with an empty StylesPath lints zero files and exits 0. Hence the
+      # canary below, and never `sync: false`.
       - uses: vale-cli/vale-action@v3
         with:
           version: 3.20.0
           reporter: github-pr-review
           filter_mode: nofilter
-          fail_on_error: true
+          fail_level: any
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Prove the rule set is actually live. If the package ever syncs without
+      # its config, the step above passes over zero rules; this fails instead.
+      - name: Assert the house voice is loaded
+        run: |
+          vale ls-config | grep -q '"Moose"' \
+            || { echo "::error::Vale loaded no Moose styles - the gate would pass over nothing"; exit 1; }

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -53,9 +53,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Prove the rule set is actually live. If the package ever syncs without
-      # its config, the step above passes over zero rules; this fails instead.
-      - name: Assert the house voice is loaded
+      # Prove the rule set is actually live. Every `BasedOnStyles` lives in the
+      # package's own config, so a sync landing nothing makes Vale lint zero
+      # files and exit 0. The action throws on a failed fetch; this catches a
+      # fetch that "succeeds" without the config. Checked against the synced
+      # tree rather than the `vale` binary, which the action installs into the
+      # tool cache without putting it on PATH.
+      - name: Assert the rule set synced
+        shell: bash
         run: |
-          vale ls-config | grep -q '"Moose"' \
-            || { echo "::error::Vale loaded no Moose styles - the gate would pass over nothing"; exit 1; }
+          compgen -G '.vale/styles/.vale-config/*.ini' >/dev/null \
+            || { echo "::error::Vale synced no style config - the gate would pass over nothing"; exit 1; }

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,25 +1,29 @@
-# House voice for every document in this repo. The Moose package enables the
-# Voices core, the Direct voice, and the Moose house rules for all Markdown
-# and text files. No voice exemptions: README, ADRs, and CLAUDE.md are all
-# held to the same standard.
+# House voice for this repo's own prose: README, the ADRs, and CLAUDE.md.
+# The Moose package enables the Voices core, the Direct voice, and the Moose
+# house rules for Markdown and text files. Test input is exempted below;
+# nothing else is.
+#
+# The package is pinned. CI gates on it, so an upstream release must not be
+# able to redden every open pull request on a day nobody chose. Moving the pin
+# is a deliberate commit, the way the TGDP pin is.
 # Package source: https://github.com/hawkeyexl/moose-vale
 StylesPath = .vale/styles
 MinAlertLevel = suggestion
-Packages = https://github.com/hawkeyexl/moose-vale/releases/latest/download/Moose.zip
+Packages = https://github.com/hawkeyexl/moose-vale/releases/download/v0.3.3/Moose.zip
 
-# Test input is not this repo's prose, so no voice applies to it.
+# Test input is not this repo's prose, so no voice applies to it. See
+# "Built-in templates are derived, not authored" in CLAUDE.md for why the
+# vendored fixtures in particular must stay byte-for-byte upstream's.
 #
-# `test/fixtures/tgdp/` holds The Good Docs Project templates vendored
-# verbatim at the pinned release, and `test/integration/tgdp.test.ts` lints
-# them to prove our doctype templates still mirror upstream. Rewriting one to
-# quiet an alert would break the comparison it exists to make, and upstream is
-# the authority on its own wording.
-#
-# The rest of `test/fixtures/` is input chosen for what it parses to, and
-# `how-to-broken.md` is wrong on purpose. `artifacts/` is the same: sample
-# documents to run the linter against.
-[test/fixtures/**]
+# The `**/` prefixes matter. Vale matches these globs against the path as it
+# was invoked, not against the repo root, so a bare `test/fixtures/**` exempts
+# nothing under an absolute path or a run from inside `test/` -- which is what
+# editor plugins and language servers pass. Naming the directory rather than
+# its full path also covers a future `test/e2e/fixtures/`. Running from inside
+# a fixture directory itself still sees no exempt segment; that is a Vale glob
+# limitation, so lint from the repo root.
+[**/fixtures/**]
 BasedOnStyles =
 
-[artifacts/**]
+[**/artifacts/**]
 BasedOnStyles =

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,8 +1,25 @@
 # House voice for every document in this repo. The Moose package enables the
 # Voices core, the Direct voice, and the Moose house rules for all Markdown
-# and text files. No section exemptions: README, ADRs, CLAUDE.md, and the
-# docs site are all held to the same voice.
+# and text files. No voice exemptions: README, ADRs, and CLAUDE.md are all
+# held to the same standard.
 # Package source: https://github.com/hawkeyexl/moose-vale
 StylesPath = .vale/styles
 MinAlertLevel = suggestion
 Packages = https://github.com/hawkeyexl/moose-vale/releases/latest/download/Moose.zip
+
+# Test input is not this repo's prose, so no voice applies to it.
+#
+# `test/fixtures/tgdp/` holds The Good Docs Project templates vendored
+# verbatim at the pinned release, and `test/integration/tgdp.test.ts` lints
+# them to prove our doctype templates still mirror upstream. Rewriting one to
+# quiet an alert would break the comparison it exists to make, and upstream is
+# the authority on its own wording.
+#
+# The rest of `test/fixtures/` is input chosen for what it parses to, and
+# `how-to-broken.md` is wrong on purpose. `artifacts/` is the same: sample
+# documents to run the linter against.
+[test/fixtures/**]
+BasedOnStyles =
+
+[artifacts/**]
+BasedOnStyles =

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ npm test                  # vitest
 npm run typecheck         # tsc --noEmit
 npm run build             # tsup -> dist/
 npm run smoke             # build, then exercise the real dist/cli.js
-npm run lint:prose        # vale sync, then vale over the repo's own prose
+npm run lint:prose        # the house voice, over this repo's own prose
 npm run check:tgdp-pin    # has upstream moved past the pinned TGDP release?
 ```
 
@@ -133,14 +133,24 @@ The pre-commit hook runs `typecheck` and `test`.
 
 ### Prose is linted too
 
-`npm run lint:prose` runs [Vale](https://vale.sh) against the house voice, and
-CI fails on any alert. It needs `vale` on your PATH; the styles themselves are
-fetched by `vale sync` and are not committed.
+`npm run lint:prose` runs [Vale](https://vale.sh) against the house voice and
+fails on any alert at any severity, exactly as CI does. It needs `vale` on your
+PATH; the styles themselves are fetched by `vale sync` and are not committed.
+Pass `-- --no-sync` to skip the fetch offline.
+
+The script exists because `vale`'s own exit status covers error-level alerts
+only, and one enabled rule is a warning. A bare `vale .` would pass locally
+what the gate fails.
 
 The scope is this repo's own prose: README, ADRs, and this file. Test fixtures
 and `artifacts/` are exempt in `.vale.ini`, because `test/fixtures/tgdp/` is
 vendored verbatim from upstream and the rest is input chosen for what it parses
 to. Rewriting either to quiet an alert would break the test that reads it.
+
+The rule package is pinned in `.vale.ini`, for the reason the TGDP templates
+are. A gate whose rules arrive from `latest` can turn every open pull request
+red on a day nobody chose. Move the pin deliberately, and expect prose work.
+See [ADR 01008](adrs/01008-gate-on-prose-lint-against-a-pinned-rule-set.md).
 
 ## Pre-1.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ Guidance for agents working in this repository.
 
 A TypeScript CLI (published to npm) that validates the **structure** of a
 document against a doctype template, routed by the page's own `type` frontmatter.
-The pipeline is: resolve targets → parse to a generic section tree → resolve a
-template per file → match sections to rules → run content rules → report.
+The pipeline resolves targets, parses each to a generic section tree, resolves a
+template per file, matches sections to rules, runs content rules, and reports.
 
 It is **deterministic**. There is no language model, and there are no network
 calls except fetching a template you point it at. If you find yourself reaching
@@ -15,19 +15,20 @@ for inference, the answer belongs in `moose-docevals`, not here.
 
 Key layers:
 
-- `src/parsers/` — per-format parsing behind the `DocumentParser` interface
+- `src/parsers/` holds per-format parsing behind the `DocumentParser` interface
   (`src/types.ts`). Each parser flattens its own AST into ordered `Block`s;
   `sectionize.ts` folds those into the `SectionNode` tree once, for every format.
   A new format is one file plus a line in `src/parsers/index.ts`.
-- `src/core/match.ts` — which rule describes which section. Read the file header
-  before touching it; the decisions are subtle and each has a test.
-- `src/core/resolve-template.ts` — which template describes which page.
-- `src/rules/` — content rules over the generic content model.
-- `src/commands/` — command cores (`lint`, `templates`, `formats`), kept free of
-  CLI/IO plumbing so they can be unit-tested directly.
-- `src/cli.ts` — thin commander wrapper over the command cores.
-- `src/reporters/` — output formatting (pretty / json / github / sarif).
-- `src/templates/` — built-in doctype templates, and the manifest registering them.
+- `src/core/match.ts` decides which rule describes which section. Read the file
+  header before touching it; the decisions are subtle and each has a test.
+- `src/core/resolve-template.ts` decides which template describes which page.
+- `src/rules/` holds the content rules over the generic content model.
+- `src/commands/` holds the command cores (`lint`, `templates`, `formats`), kept
+  free of CLI/IO plumbing so they can be unit-tested directly.
+- `src/cli.ts` is a thin commander wrapper over the command cores.
+- `src/reporters/` formats output (pretty / json / github / sarif).
+- `src/templates/` holds the built-in doctype templates and the manifest that
+  registers them.
 
 ## Working agreements
 
@@ -38,17 +39,17 @@ Project preferences. Follow them unless the user says otherwise.
 Everything downstream of `parse()` operates on `SectionNode` and `ContentNode`.
 **Rules must never reach for mdast node types**, or the parser registry is a
 fiction and every rule silently becomes Markdown-only. If a rule needs something
-the content model cannot express, grow the model — which means touching every
-parser, deliberately — rather than special-casing one format.
+the content model cannot express, grow the model rather than special-casing one
+format. Growing it means touching every parser, deliberately.
 
 ### Red/green TDD
 
 Develop test-first:
 
-1. **Red**: write or adjust tests for the new behavior and run them; confirm they
-   fail for the right reason.
-2. **Green**: implement the minimum to make them pass.
-3. **Refactor**: clean up with the tests as a safety net.
+1. **Red**. Write or adjust tests for the new behavior and run them. Confirm
+   they fail for the right reason.
+2. **Green**. Implement the minimum to make them pass.
+3. **Refactor**. Clean up with the tests as a safety net.
 
 When a behavior change makes existing tests fail correctly, update those tests as
 part of the red step rather than working around them.
@@ -86,8 +87,8 @@ findings, **2** operational or usage error. A `MooseLintError` always means 2.
 ### The JSON reporter's shape is an API
 
 `moose-docevals` parses `[{ file, success, errors: [...] }]` off stdout, and it
-*parses* rather than validates — a renamed key yields zero findings, not an
-error. Adding keys is safe; renaming or nesting is not. `test/unit/reporters.test.ts`
+*parses* rather than validates, so a renamed key yields zero findings instead of
+an error. Adding keys is safe; renaming or nesting is not. `test/unit/reporters.test.ts`
 pins it deliberately.
 
 ### Built-in templates are derived, not authored
@@ -96,15 +97,15 @@ The templates under `src/templates/tgdp/` mirror The Good Docs Project at a
 pinned release. Upstream is the authority: `test/integration/tgdp.test.ts` lints
 TGDP's own published template, vendored verbatim, against ours. **Never edit a
 vendored fixture to make a template pass.** If they disagree, the template is
-wrong. When moving the pin, bump the version in every id — a version in an id is
+wrong. When moving the pin, bump the version in every id. A version in an id is
 a claim about which upstream revision it mirrors.
 
 ### One config file, one key
 
 Settings live in a shared `moose.config.yaml`, and this tool reads only the
 `lint:` key. Sibling tools' keys are neither read nor validated. Within our
-section, validation is strict (`additionalProperties: false` at every level) —
-that is what turns a typo into a loud failure instead of a silent default.
+section, validation is strict (`additionalProperties: false` at every level).
+That strictness turns a typo into a loud failure instead of a silent default.
 
 Do not add JSON Schema `default`s to booleans in either schema. A written-in
 default is indistinguishable from a value the author typed, and it beat inherited
@@ -113,7 +114,7 @@ values in `extends` merges once already.
 ### Record decisions
 
 Non-obvious decisions go in `adrs/`, in the format the existing records use.
-Name the options you rejected and what was good about them, and write the
+Name the options you rejected and what was good about them. Write the
 Confirmation section naming the tests that would fail if the decision were
 reversed. See [`adrs/README.md`](adrs/README.md).
 
@@ -124,10 +125,22 @@ npm test                  # vitest
 npm run typecheck         # tsc --noEmit
 npm run build             # tsup -> dist/
 npm run smoke             # build, then exercise the real dist/cli.js
+npm run lint:prose        # vale sync, then vale over the repo's own prose
 npm run check:tgdp-pin    # has upstream moved past the pinned TGDP release?
 ```
 
 The pre-commit hook runs `typecheck` and `test`.
+
+### Prose is linted too
+
+`npm run lint:prose` runs [Vale](https://vale.sh) against the house voice, and
+CI fails on any alert. It needs `vale` on your PATH; the styles themselves are
+fetched by `vale sync` and are not committed.
+
+The scope is this repo's own prose: README, ADRs, and this file. Test fixtures
+and `artifacts/` are exempt in `.vale.ini`, because `test/fixtures/tgdp/` is
+vendored verbatim from upstream and the rest is input chosen for what it parses
+to. Rewriting either to quiet an alert would break the test that reads it.
 
 ## Pre-1.0
 

--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ npm install
 npm test
 npm run typecheck
 npm run smoke            # build, then exercise the real dist/cli.js
-npm run lint:prose       # Vale, against the house voice (needs `vale` on PATH)
+npm run lint:prose       # the house voice (needs `vale` on PATH)
 npm run check:tgdp-pin   # has upstream moved past the built-ins' pin?
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ built for CI.
 > positional, and `instructions:` has been removed from the template format. See
 > [Migrating](#migrating-from-doc-structure-lint).
 
-`moose-lint` checks that a page has the shape it claims to have: the sections a
-doctype calls for, in order, holding the paragraphs, code blocks, and lists that
-doctype requires. It reads the document as a syntax tree — it does not pattern-match
-source text — and it does not judge prose. Every run is a function of the document
-and the template, so the same inputs always produce the same findings.
+`moose-lint` checks that a page has the shape it claims to have. A doctype calls
+for certain sections, in order, holding certain paragraphs, code blocks, and
+lists. It reads the document as a syntax tree rather than pattern-matching source
+text, and it does not judge prose. Every run is a function of the document and
+the template, so the same inputs always produce the same findings.
 
 It is one of a family of documentation tools, and it deliberately does one job:
 
@@ -58,8 +58,8 @@ moose-lint docs/
 3 files checked, 1 passed, 2 failed, 1 skipped
 ```
 
-A clean run exits `0`, findings exit `1`, and an operational error — no inputs, an
-unreadable template, an invalid template — exits `2`.
+A clean run exits `0` and findings exit `1`. An operational error exits `2`,
+whether that is no inputs, an unreadable template, or an invalid template.
 
 ## Routing by `type`
 
@@ -75,8 +75,8 @@ type: how-to
 ```
 
 `type` is the same key `moose-meta`'s OKF, Diataxis, and TGDP schemas already
-validate, so a repo that types its pages gets routing for free — and one run can
-lint a tree of mixed doctypes, each page checked against the doctype it claims.
+validate, so a repo that types its pages gets routing for free. One run can lint
+a tree of mixed doctypes, and each page is checked against the doctype it claims.
 The seven [built-in templates](#built-in-doctype-templates) cover the common
 ones out of the box.
 
@@ -97,17 +97,17 @@ Steps 3 and 5 are repo policy, written in
 
 Two of these come out of the document, and the difference between them is what
 `$template` is restricted for. A page's `type` is document-controlled, but it
-only *selects* from the routing table the operator assembled — a page cannot
+only *selects* from the routing table the operator assembled. A page cannot
 introduce a template that way, only ask for one already on offer. `$template`
 names a reference directly, which is the one place a document says where a
 template comes from rather than which one it wants.
 
-So `$template` cannot name a URL. A relative path or a built-in id is fine —
+So `$template` cannot name a URL. A relative path or a built-in id is fine.
 `$template: ./house.yaml#house` resolves beside the page that wrote it, not
-beside wherever you ran the command — but `$template: https://…` is refused with
-a `template_error`. Otherwise one line of frontmatter would make the machine
-doing the linting fetch whatever that docset asked for, from inside whatever
-network the CI job runs in. An operator who does want a remote template still
+beside wherever you ran the command. But `$template: https://…` is refused with
+a `template_error`. Otherwise one line of frontmatter would make the linting
+machine fetch whatever that docset asked for, from inside the CI job's own
+network. An operator who does want a remote template still
 has steps 1, 3, 4, and 5.
 
 ### A missing `type` and an unknown one are different
@@ -119,14 +119,14 @@ apart, it does not fail the run, and its neighbours are still checked.
 - docs/notes.md  skipped: no type in frontmatter and no template resolved
 ```
 
-An untyped page is `moose-meta`'s complaint, not this tool's — its OKF schema
+An untyped page is `moose-meta`'s complaint, not this tool's. Its OKF schema
 already requires `type`. Skipping is what lets you point `moose-lint` at a whole
 tree on day one, when three pages out of two hundred are typed.
 
 **Unless nothing at all was checked.** A run that finds files and checks none of
-them exits `2`, because a linter that looked at nothing is indistinguishable
-from a clean docset once it exits `0` — and a repo that adopts `moose-lint` in
-CI before backfilling `type:` keys would get a permanently green job over an
+them exits `2`. A linter that looked at nothing is indistinguishable from a
+clean docset once it exits `0`. A repo that adopts `moose-lint` in CI before
+backfilling `type:` keys would otherwise get a permanently green job over an
 unchecked tree.
 
 ```text
@@ -153,9 +153,9 @@ checked and nobody finding out.
 ### `--explain`
 
 `--explain` prints how each file's template was chosen, and lints nothing. Every
-stage is listed, including the ones that had nothing to say: "why was this page
-linted with *that*?" is usually asked because the answer was surprising, and the
-surprising part is almost always a stage you forgot applies.
+stage is listed, including the ones that had nothing to say. People ask "why was
+this page linted with *that*?" because the answer surprised them. The surprising
+part is almost always a stage you forgot applies.
 
 ```bash
 moose-lint docs/ --explain
@@ -193,13 +193,13 @@ moose-lint docs/ --explain
 ```
 
 `▸` means the page was routed and `-` that it was not. Neither is a verdict on
-the document — `docs/configure.md` is routed and still fails the lint above — and
-`--explain` exits `0` however the docs look. It answers a question about
+the document, since `docs/configure.md` is routed and still fails the lint
+above. `--explain` exits `0` however the docs look. It answers a question about
 configuration, not about the documents.
 
-That includes pages it could not route at all: a `type` no template serves
+That includes pages it could not route at all. A `type` no template serves
 prints a `✗` line and still exits `0`, because "nothing serves this type" is an
-answer. So do not gate CI on `--explain`'s exit code — it will pass over a
+answer. So do not gate CI on `--explain`'s exit code. It will pass over a
 docset whose every page is unrouted. The ordinary run is what reports that, and
 exits `1`.
 
@@ -215,7 +215,7 @@ moose-lint formats      List input formats, implemented and planned
 ```
 
 `-t/--template <ref>` is optional. Given, it applies one template to every file
-in the run and overrides routing entirely — which is what you want for a single
+in the run and overrides routing entirely. That is what you want for a single
 page, and what you do not want for a tree.
 
 `--templates <path>` adds a template file to the run: its templates' `types:`
@@ -242,21 +242,21 @@ moose-lint formats
 | XML | `.dita` in directory walks; `.xml` and `.dita` when named | root-element attributes |
 
 One template checks all of them. The same `tgdp:how-to:1.6` lints a Markdown
-page, an AsciiDoc page, and a DITA topic, and reports **the same findings** —
+page, an AsciiDoc page, and a DITA topic, and reports **the same findings**.
 `test/integration/cross-format.test.ts` holds a fixture pair per format and
 asserts exactly that. If a template ever needed per-format special-casing, the
 content model would be wrong.
 
-Each parser maps its own vocabulary onto three generic content kinds —
-`paragraph`, `code`, `list`. Anything a doctype template cannot describe
+Each parser maps its own vocabulary onto three generic content kinds:
+`paragraph`, `code`, and `list`. Anything a doctype template cannot describe
 (blockquotes, tables, admonitions, figures) is **skipped rather than
-approximated**: counting a table as a list would make `lists: {max: 1}` fail
+approximated**. Counting a table as a list would make `lists: {max: 1}` fail
 documents that satisfy it.
 
 XML is the one format with no universal notion of a section, because that comes
 from the schema rather than the syntax. It ships declarative vocabulary mappings
 for **DITA** and **DocBook**, selected by scoring the document's root element,
-namespace, and element names; a bespoke schema is one more entry in the same
+namespace, and element names. A bespoke schema is one more entry in the same
 table. See the header of [`src/parsers/xml.ts`](src/parsers/xml.ts).
 
 ## Template format
@@ -291,10 +291,10 @@ templates:
 ```
 
 `types:` is what makes a template you wrote first-class rather than a fallback.
-Built-ins are loaded first and user templates overwrite them, so overriding the
-how-to doctype for a repo is one file with `types: [how-to]` in it — no config
-entry, no flag beyond `--templates`. A doctype your file does not claim stays on
-its built-in.
+Built-ins are loaded first and user templates overwrite them. Overriding the
+how-to doctype for a repo is one file with `types: [how-to]` in it, with no
+config entry and no flag beyond `--templates`. A doctype your file does not
+claim stays on its built-in.
 
 ```bash
 moose-lint docs/ --templates ./templates.yaml
@@ -325,7 +325,7 @@ by page.
 `repeat` is what a rule sets to claim more than one section, and it applies to
 both kinds of rule:
 
-- On an **anchored** rule — one with `heading.const` or `heading.pattern` — it
+- On an **anchored** rule, one with `heading.const` or `heading.pattern`, it
   claims the run of consecutive sections whose headings satisfy it. That is how
   a doctype says "one or more sections named `Symptom N`" without giving up
   checking the heading text.
@@ -333,8 +333,8 @@ both kinds of rule:
   claim one.
 
 Without it either kind claims exactly one section, so two adjacent slots each get
-their own. That default is deliberate: adjacent unconstrained sections are
-ordinary in hand-written templates, and a greedy first slot would swallow the
+their own. That default is deliberate. Adjacent unconstrained sections are
+ordinary in hand-written templates. A greedy first slot would swallow the
 second one's section and then report it missing.
 
 ### Content rules
@@ -375,16 +375,16 @@ templates:
         $ref: "#/components/parameters"
 ```
 
-`extends` inherits another template — a built-in id, a path, or a URL. The merge
-recurses through `sections` by key, so tightening or relaxing one nested rule
-keeps its siblings; every other key the child sets replaces the parent's
-outright.
+`extends` inherits another template, whether a built-in id, a path, or a URL.
+The merge recurses through `sections` by key, so tightening or relaxing one
+nested rule keeps its siblings. Every other key the child sets replaces the
+parent's outright.
 
 That is how you keep a built-in and disagree with one part of it.
 `tgdp:how-to:1.6` requires a `See also` section, because upstream ships one and
 does not mark it optional the way it marks `Before you start`. Plenty of real
 how-tos have none. To keep the rest of the doctype and drop that one
-requirement — this is `house-how-to` in [`templates.yaml`](templates.yaml):
+requirement, use the `house-how-to` entry in [`templates.yaml`](templates.yaml):
 
 ```yaml
 templates:
@@ -449,13 +449,13 @@ moose-lint templates
 ```
 
 Each built-in is round-trip tested. `test/integration/tgdp.test.ts` lints TGDP's
-own published `template_<slug>.md` — vendored verbatim under
-`test/fixtures/tgdp/` — against the template derived from it, and requires zero
+own published `template_<slug>.md`, vendored verbatim under
+`test/fixtures/tgdp/`, against the template derived from it, and requires zero
 findings. Where the two disagree, upstream is right. That is what makes
 "publicly vetted" checkable rather than a claim.
 
 The version in an id is a promise about which upstream revision the template
-mirrors, so `npm run check:tgdp-pin` asks GitLab whether upstream has moved past
+mirrors. `npm run check:tgdp-pin` asks GitLab whether upstream has moved past
 the pin and reports what moving it would involve. It is a report, not a gate:
 upstream moving does not make the pinned templates wrong, it makes them old.
 
@@ -467,7 +467,7 @@ render the page title from frontmatter, so their pages legitimately start at
 `##` and have no H1 to match.
 
 Those pages work. When a page carries a frontmatter `title` and its body has no
-H1, that title *is* the document's H1 — findings about it are anchored on the
+H1, that title *is* the document's H1. Findings about it are anchored on the
 frontmatter, where the title actually lives:
 
 ```markdown
@@ -492,7 +492,7 @@ also struggle to name.
 ### One thing that will bite you
 
 **`tgdp:how-to:1.6` requires `See also`.** Upstream includes it unconditionally
-and never marks it optional, so the derived template requires it — and plenty of
+and never marks it optional, so the derived template requires it. Plenty of
 real how-tos have none. Rather than substitute our judgment for TGDP's, relaxing
 it is the worked [`extends` example](#reuse): one file, four lines.
 
@@ -502,8 +502,8 @@ Optional. A repo whose pages all declare their `type` needs none.
 
 Settings live in **`moose.config.yaml`**, one file shared by the whole moose
 family, with one top-level key per tool. `moose-lint` reads `lint:` and neither
-reads nor validates anything else, so the file grows as you adopt more of the
-family without any tool needing to know about the others.
+reads nor validates anything else. The file grows as you adopt more of the
+family, and no tool needs to know about the others.
 
 ```yaml
 # moose.config.yaml
@@ -528,13 +528,13 @@ Discovery walks up from the working directory to the repository root, so it
 works from a subdirectory. `-c/--config <path>` names a file directly and skips
 discovery.
 
-Command-line flags win over the file, with one exception: `--exclude`
-**accumulates** with the configured excludes rather than replacing them, because
-narrowing a run should not quietly discard the repo's standing exclusions.
+Command-line flags win over the file, with one exception. `--exclude`
+**accumulates** with the configured excludes rather than replacing them.
+Narrowing a run should not quietly discard the repo's standing exclusions.
 
 ### What fails loudly
 
-Validation inside `lint:` is strict — unknown keys are an error, not a silent
+Validation inside `lint:` is strict. Unknown keys are an error, not a silent
 default. Beyond that, four shapes are rejected rather than defaulted through,
 because each one silently discards a whole configuration:
 
@@ -559,7 +559,7 @@ const run = await runLint({ inputs: ["docs/"] });
 ```
 
 `template` and `templates` are optional and mirror `--template` and
-`--templates`. `runLint` reads no configuration file — it is a function of the
+`--templates`. `runLint` reads no configuration file. It is a function of the
 options you hand it, so a library caller is never surprised by a file on disk.
 Call `loadConfig()` yourself if you want the file.
 
@@ -570,14 +570,14 @@ Call `loadConfig()` yourself if you want the file.
 | `pretty` | reading. The default. |
 | `json` | tool adapters: `[{ file, success, errors: [{ type, heading, message, position }] }]` |
 | `github` | GitHub workflow commands (`::error file=…,line=…,col=…::`), inline on a pull request |
-| `sarif` | code-scanning uploads — SARIF 2.1.0, one rule descriptor per finding type |
+| `sarif` | SARIF 2.1.0 for code-scanning uploads, one rule descriptor per finding type |
 
 The SARIF output declares every finding type in `tool.driver.rules` and
-references it by both `ruleId` and `ruleIndex`, so alerts group and filter
+references it by both `ruleId` and `ruleIndex`. Alerts then group and filter
 properly rather than arriving as a flat list. Paths are relative and
 forward-slashed against a declared `SRCROOT`, on Windows as well as Linux.
-Skipped files become `note`-level notifications rather than results: a skip is a
-statement about the tool, which declined to look, not about the document — as
+Skipped files become `note`-level notifications rather than results. A skip is a
+statement about the tool, which declined to look, not about the document. As
 results they would open alerts on files nothing examined.
 
 ```bash
@@ -603,14 +603,14 @@ still uses it fails with a message containing the replacement config to paste. S
 
 Section matching also changed. It used to pair template rules to document sections
 by array index, so a single absent optional section misaligned every comparison
-after it. It is now one ordered pass over heading identity — see
+after it. It is now one ordered pass over heading identity. See
 [ADR 01002](adrs/01002-match-sections-in-order-not-by-index.md). Templates that
 worked before still work once `instructions:` and the `doc-structure-lint:`
 version key are gone; templates with optional sections now work *correctly*.
 
 `--template` still applies one template to every file, so an existing invocation
 keeps working unchanged. Adding `types:` to your templates and dropping the flag
-is what turns a per-doctype run into one run over the whole tree — see
+turns a per-doctype run into one run over the whole tree. See
 [ADR 01004](adrs/01004-route-templates-by-the-type-frontmatter-key.md) and
 [ADR 01005](adrs/01005-ship-tgdp-structure-templates-without-demoting-user-templates.md).
 
@@ -621,12 +621,13 @@ npm install
 npm test
 npm run typecheck
 npm run smoke            # build, then exercise the real dist/cli.js
+npm run lint:prose       # Vale, against the house voice (needs `vale` on PATH)
 npm run check:tgdp-pin   # has upstream moved past the built-ins' pin?
 ```
 
 `npm run smoke` exists because the suite runs against `src/`, where the built-in
 templates sit one directory deeper than they do in the bundled `dist/`. A path
-that is right in the repo and wrong in the package passes every test — which is
+that is right in the repo and wrong in the package passes every test. That is
 how it happened once.
 
 Decisions are recorded in [`adrs/`](adrs/), and the conventions this rewrite
@@ -634,4 +635,4 @@ settled on are in [`CLAUDE.md`](CLAUDE.md).
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).

--- a/adrs/01001-derive-structure-from-an-ast-behind-a-format-registry.md
+++ b/adrs/01001-derive-structure-from-an-ast-behind-a-format-registry.md
@@ -62,8 +62,9 @@ adding parsers that each invent their own output shape.
 The chosen option is **a `DocumentParser` registry producing one generic
 `DocumentTree`**. It mirrors `docmeta`'s extractor registry file for file
 (`parserForExtension`, `parserByName` for `--as`, `supportedExtensions()` for
-directory walks, `listFormats()`). That was chosen over an interface shaped like
-its `MetadataExtractor`.
+directory walks, `listFormats()`). The per-format interface underneath it is
+shaped after `docmeta`'s `MetadataExtractor`, so the two registries read the
+same way.
 
 The pipeline runs a format-specific parse, then a format-specific flattening
 into ordered `Block`s, then **one shared `sectionize` fold**, and out comes a

--- a/adrs/01001-derive-structure-from-an-ast-behind-a-format-registry.md
+++ b/adrs/01001-derive-structure-from-an-ast-behind-a-format-registry.md
@@ -9,27 +9,30 @@ decision-makers: [hawkeyexl]
 ## Context and Problem Statement
 
 `doc-structure-lint` called remark and then discarded the tree. `parseMarkdown`
-walked the mdast with a mutable `currentSection` cursor, re-derived parentage by
-linear `findParent` scans over the whole result on every node, re-serialized
-nodes back into strings with `getNodeRawContent`, maintained section end offsets
-by hand through `updateParentPositions`, and recorded every piece of content
-**twice** — once into `paragraphs`/`codeBlocks`/`lists` buckets and again into a
-parallel `content` array of run-grouped objects for the `sequence` rule.
+walked the mdast with a mutable `currentSection` cursor, and from there:
 
-Two costs followed. Fidelity: heading titles were built with
-`children.map(c => c.value).join("")`, and `value` is undefined on anything but a
-text node, so `# Use the \`lint\` command` yielded `Use the  command`. Frontmatter
-was parsed by splitting lines on `:`, so a list or a nested mapping became a
-string. Section spans ended at their own last child rather than where the next
-section begins.
+- It re-derived parentage by linear `findParent` scans over the whole result, on
+  every node.
+- It re-serialized nodes back into strings with `getNodeRawContent`.
+- It maintained section end offsets by hand through `updateParentPositions`.
+- It recorded every piece of content **twice**, once into
+  `paragraphs`/`codeBlocks`/`lists` buckets and again into a parallel `content`
+  array of run-grouped objects for the `sequence` rule.
 
-The larger cost was structural. A second format had been attempted —
-`parsers/asciidoc.js` existed — but it emitted a completely different shape
+Two costs followed. The first was fidelity. Heading titles were built with
+`children.map(c => c.value).join("")`, and `value` is undefined on anything but
+a text node. So `# Use the \`lint\` command` yielded `Use the  command`.
+Frontmatter was parsed by splitting lines on `:`, so a list or a nested mapping
+became a string. Section spans ended at their own last child rather than where
+the next section begins.
+
+The larger cost was structural. A second format had been attempted, and
+`parsers/asciidoc.js` existed. But it emitted a completely different shape
 (`startIndex`/`endIndex`/`subsections`, with paragraphs and code blocks as
 integer *counts*) than the Markdown parser's (`position`/arrays/`sections`).
-Nothing downstream could consume both, so the AsciiDoc path was never wired in:
-`inferFileType` had its AsciiDoc branch commented out and defaulted every
-unrecognized extension — `.rst`, `.html`, `.adoc` — to Markdown, and
+Nothing downstream could consume both, so the AsciiDoc path was never wired in.
+`inferFileType` had its AsciiDoc branch commented out, and defaulted every
+unrecognized extension to Markdown, `.rst` and `.html` and `.adoc` alike, and
 `getSupportedFiles` hardcoded `[".md", ".markdown"]`.
 
 The tool needs to reach the formats `docmeta` already extracts metadata from
@@ -56,38 +59,38 @@ adding parsers that each invent their own output shape.
 
 ## Decision Outcome
 
-Chosen option: **a `DocumentParser` registry producing one generic
-`DocumentTree`**, mirroring `docmeta`'s extractor registry file for file
+The chosen option is **a `DocumentParser` registry producing one generic
+`DocumentTree`**. It mirrors `docmeta`'s extractor registry file for file
 (`parserForExtension`, `parserByName` for `--as`, `supportedExtensions()` for
-directory walks, `listFormats()`), over an interface shaped like its
-`MetadataExtractor`.
+directory walks, `listFormats()`). That was chosen over an interface shaped like
+its `MetadataExtractor`.
 
-The pipeline is: format-specific parse → format-specific flattening into ordered
-`Block`s → **one shared `sectionize` fold** → `SectionNode` tree. Only the first
-two steps are per-format; nesting, slugging, ordering, and span computation are
-written once. For Markdown and MDX the flattening is a walk over mdast; a future
-AsciiDoc parser walks Asciidoctor's block tree and an HTML parser walks parse5's
-DOM, and neither touches the fold.
+The pipeline runs a format-specific parse, then a format-specific flattening
+into ordered `Block`s, then **one shared `sectionize` fold**, and out comes a
+`SectionNode` tree. Only the first two steps are per-format. Nesting, slugging,
+ordering, and span computation are written once. For Markdown and MDX the
+flattening is a walk over mdast. A future AsciiDoc parser walks Asciidoctor's
+block tree and an HTML parser walks parse5's DOM, and neither touches the fold.
 
 **The content model is deliberately format-neutral.** A `SectionNode` exposes its
-content as ordered nodes of kind `paragraph`, `code`, or `list` — not as mdast
-node types. Each parser maps its own vocabulary on (mdast
+content as ordered nodes of kind `paragraph`, `code`, or `list`, rather than as
+mdast node types. Each parser maps its own vocabulary on (mdast
 `paragraph`/`code`/`list`, Asciidoctor `paragraph`/`listing`/`ulist`, HTML
 `<p>`/`<pre>`/`<ul>`). This is what lets one `tgdp:how-to` template check a
-Markdown page and an AsciiDoc page and produce the same findings. Block types the
-DSL does not describe — blockquotes, tables, thematic breaks — are skipped rather
-than mapped to a nearest neighbour, because counting a table as a list would make
-`lists: {max: 1}` fail documents that satisfy it.
+Markdown page and an AsciiDoc page and produce the same findings. Block types
+the DSL does not describe, such as blockquotes, tables, and thematic breaks, are
+skipped rather than mapped to a nearest neighbour. Counting a table as a list
+would make `lists: {max: 1}` fail documents that satisfy it.
 
 **Unimplemented formats are registered as stubs**, again following `docmeta`.
 A stub carries `implemented: false` and throws a named error. That is what turns
-`.rst` from a file quietly parsed as Markdown into a reported gap, and what lets
+`.rst` from a file quietly parsed as Markdown into a reported gap. It also lets
 `moose-lint formats` state the roadmap rather than leaving users to discover it.
 
-MDX gets its own registered parser rather than a flag on the Markdown one:
+MDX gets its own registered parser rather than a flag on the Markdown one.
 `remark-mdx` reads `{` as an expression delimiter, so ordinary Markdown prose
 containing a brace is a syntax error under it. One processor for both formats
-breaks either MDX or Markdown; `moose-kg` reached the same conclusion.
+breaks either MDX or Markdown, and `moose-kg` reached the same conclusion.
 
 ### Consequences
 
@@ -95,36 +98,40 @@ breaks either MDX or Markdown; `moose-kg` reached the same conclusion.
   `getNodeRawContent`, `addToSequence`, `findParent`, `updateParentPositions`,
   `createDefaultSection`, and the generated `uuid` identities. On a tree those
   are queries, not state.
-- Good, because the fidelity bugs go away as a side effect rather than as fixes:
-  titles come from `mdast-util-to-string`, slugs from `github-slugger`,
+- Good, because the fidelity bugs go away as a side effect rather than as fixes.
+  Titles come from `mdast-util-to-string`, slugs from `github-slugger`,
   frontmatter from `docmeta`'s extractor (nested mappings and lists included),
   and positions from unist.
-- Good, because a section now ends where the next section at its level begins,
-  so findings span what a reader would call the section and adjacent sections
-  tile the document with no gaps.
+- Good, because a section now ends where the next section at its level begins.
+  Findings span what a reader would call the section, and adjacent sections tile
+  the document with no gaps.
 - Good, because `inferFileType` and the hardcoded extension list are gone;
   file walking asks the registry.
 - Bad, because there are two hops from source to rules (parse, then flatten)
-  rather than one, and a format whose native tree is far from
-  heading-plus-content — XML vocabularies like DITA — will need a mapping the
-  interface does not describe for it.
+  rather than one. Take a format whose native tree is far from
+  heading-plus-content, such as an XML vocabulary like DITA. It will need a
+  mapping the interface does not describe for it.
 - Bad, because the generic content model cannot express anything the three kinds
   do not cover. Admonitions, tables, and includes are invisible to templates
   until the model grows a kind, and growing it touches every parser.
 - Neutral, because `docmeta` is now a runtime dependency for frontmatter.
-  `moose-kg` already depends on it for the same reason and calls it the single
-  source of truth with `dockg validate`; a second frontmatter parser in the
+  `moose-kg` already depends on it for the same reason, and calls it the single
+  source of truth with `dockg validate`. A second frontmatter parser in the
   family would be the worse outcome.
 
 ### Confirmation
 
-`test/unit/parsers.test.ts` pins the tree (nesting, `order`, `parentSlug`, slug
-disambiguation), the fidelity cases the old parser failed (inline markup in a
-heading, nested frontmatter, list-item children), the span rule (a section ends
-at the next sibling heading, the last section ends at EOF), the implicit lead
-section for headless documents, the skipping of undescribed block types, the
-MDX/Markdown brace split, and the registry — including that `.rst` reports as
-not implemented and that `supportedExtensions()` excludes it.
+`test/unit/parsers.test.ts` pins:
+
+- The tree (nesting, `order`, `parentSlug`, slug disambiguation).
+- The fidelity cases the old parser failed (inline markup in a heading, nested
+  frontmatter, list-item children).
+- The span rule (a section ends at the next sibling heading, the last section
+  ends at EOF).
+- The implicit lead section for headless documents.
+- The skipping of undescribed block types, and the MDX/Markdown brace split.
+- The registry, including that `.rst` reports as not implemented and that
+  `supportedExtensions()` excludes it.
 
 `test/integration/repo-templates.test.ts` parses this repository's own sample
 documents, so the fold is exercised against real prose rather than fixtures

--- a/adrs/01002-match-sections-in-order-not-by-index.md
+++ b/adrs/01002-match-sections-in-order-not-by-index.md
@@ -15,18 +15,18 @@ by **array position**. `structureValidator.validateStructure` walked
 
 Position is only a correct identity when the two lists are the same length and in
 the same order. A template with an optional section breaks that on the first
-document that omits it: every later rule is compared against the section before
-the one it describes, so a single missing `## Background` yields a heading error
-on `## Usage`, another on `## See also`, and a spurious missing-section report at
-the end. The findings are not merely noisy — they name the wrong sections.
+document that omits it. Every later rule is then compared against the section
+before the one it describes. A single missing `## Background` yields a heading
+error on `## Usage`, another on `## See also`, and a spurious missing-section
+report at the end. The findings are not merely noisy. They name the wrong sections.
 
 The `additionalSections` branch failed differently. `validateAdditionalSections`
 decided whether a document section *was* a given template section by running full
 validation against it and treating **zero errors as identity**. Two consequences
 follow. Any two loosely constrained sections are interchangeable, because both
-validate cleanly against either rule. And a section can never be simultaneously
-matched and wrong, because being wrong is what disqualified it from matching —
-so the only report an invalid section can produce is "missing".
+validate cleanly against either rule. And a section can never be matched and
+wrong at once, because being wrong is what disqualified it from matching. So the
+only report an invalid section can produce is "missing".
 
 This mattered now because the tool is adopting published doctype templates. The
 Good Docs Project's templates are built out of optional and placeholder sections
@@ -40,11 +40,11 @@ the shape both code paths get wrong.
   this rule about?" and "is that section valid?" stay separate questions.
 - Findings must name the section the author would name, and one structural
   divergence should produce one finding, not a cascade.
-- The tool is becoming deterministic (ADR 01003); matching must be a total
-  function of the document and the template, with no dependence on evaluation
-  order or on how many errors something happened to produce.
-- Existing templates in the wild — starting with this repository's own
-  `templates.yaml` — must keep working.
+- The tool is becoming deterministic (ADR 01003). Matching must be a total
+  function of the document and the template. It must not depend on evaluation
+  order, or on how many errors something happened to produce.
+- Existing templates in the wild must keep working, starting with this
+  repository's own `templates.yaml`.
 
 ## Considered Options
 
@@ -55,14 +55,15 @@ the shape both code paths get wrong.
 
 ## Decision Outcome
 
-Chosen option: **one ordered left-to-right pass**, in `src/core/match.ts`,
+The chosen option is **one ordered left-to-right pass**, in `src/core/match.ts`,
 distinguishing two kinds of rule:
 
 - An **anchored** rule constrains heading text (`heading.const` or
-  `heading.pattern`) and claims at most one section. If the section at the cursor
-  does not satisfy it, we scan forward: a match further on means the sections in
-  between are extra, and no match anywhere means the rule is missing.
-- A **slot** rule constrains no heading text — the DSL's expression of a
+  `heading.pattern`) and claims at most one section. If the section at the
+  cursor does not satisfy it, we scan forward. A match further on means the
+  sections in between are extra, and no match anywhere means the rule is
+  missing.
+- A **slot** rule constrains no heading text, which is the DSL's expression of a
   placeholder like `{Task name}`. It claims exactly one section, or, when it sets
   `repeat: true`, every consecutive section up to the next anchored rule that
   could claim one.
@@ -73,16 +74,16 @@ is the whole fix: a rule that describes nothing consumes nothing.
 Two details are load-bearing.
 
 **Repetition is opt-in.** Greedy slots were implemented first and were wrong.
-Adjacent unconstrained sections are ordinary in hand-written templates — this
-repository's own `Sample` has `Setup` followed by `Usage` — and a greedy first
-slot consumed both, then reported `Usage` missing. `repeat` is therefore a new
+Adjacent unconstrained sections are ordinary in hand-written templates, and this
+repository's own `Sample` has `Setup` followed by `Usage`. A greedy first slot
+consumed both, then reported `Usage` missing. `repeat` is therefore a new
 key rather than the default, and only genuinely repeated placeholders set it.
 
-**A lone mismatch stays a mismatch.** When a required anchored rule matches
-nothing anywhere, and the section at the cursor is wanted by no later rule, the
-rule is paired with that section anyway and the heading rule reports
-`Expected title "X", but found "Y"`. Without this the commonest error in the
-tool's history — one section, one wrong heading — would have degraded into
+**A lone mismatch stays a mismatch.** A required anchored rule may match nothing
+anywhere while the section at the cursor is wanted by no later rule. The rule is
+then paired with that section anyway, and the heading rule reports
+`Expected title "X", but found "Y"`. The commonest error in the tool's history is
+one section with one wrong heading. Without this it would have degraded into
 `missing_section` plus `unexpected_section`, leaving the reader to work out that
 they are the same problem.
 
@@ -91,12 +92,12 @@ they are the same problem.
 - Good, because an absent optional section costs exactly nothing: the sections
   after it still match the rules that describe them.
 - Good, because matching no longer runs the rules, so a section can be both
-  matched and invalid — the report says what is wrong with it instead of
+  matched and invalid. The report says what is wrong with it instead of
   claiming it is absent.
-- Good, because it is O(n+m) with no backtracking, and total: the same document
+- Good, because it is O(n+m) with no backtracking, and total. The same document
   and template always produce the same findings in the same order.
 - Good, because `subsectionValidator` disappears. Recursion is the same function
-  applied to a matched pair's children, so there is one matching rule in the
+  applied to a matched pair's children. One matching rule remains in the
   codebase rather than two that drifted apart.
 - Bad, because the DSL grows a key (`repeat`), and a template author who wants a
   repeated placeholder must now say so.
@@ -104,21 +105,25 @@ they are the same problem.
   wins. No rule can resolve that without backtracking, and the shape does not
   occur in any template we ship.
 - Neutral, because `section_count_mismatch` is gone. It reported an arithmetic
-  disagreement about how many sections there should be; the pass now reports the
-  specific rule that went unmatched or the specific section that went unclaimed.
+  disagreement about how many sections there should be. The pass now reports the
+  specific rule that went unmatched, or the specific section that went
+  unclaimed.
 
 ### Confirmation
 
-`test/unit/match.test.ts` pins each branch: ordered anchoring, an absent optional
-rule leaving later matches intact, missing and unexpected sections, forward
-scanning past extras, pattern anchors, single and repeated slots, empty required
-and optional slots, and the coerced-mismatch message.
+`test/unit/match.test.ts` pins each branch:
+
+- Ordered anchoring, and an absent optional rule leaving later matches intact.
+- Missing and unexpected sections, and forward scanning past extras.
+- Pattern anchors, single and repeated slots, and empty required and optional
+  slots.
+- The coerced-mismatch message.
 
 `test/integration/repo-templates.test.ts` pins the combination against this
 repository's own `templates.yaml` and `artifacts/sample_markdown.md`: `Sample`
 lints clean, and the deliberately mismatched `how-to` produces exactly three
 heading mismatches rather than a cascade. That integration test is what caught
-the greedy-slot error — every unit test passed with greedy slots.
+the greedy-slot error, because every unit test passed with greedy slots.
 
 ## Pros and Cons of the Options
 

--- a/adrs/01002-match-sections-in-order-not-by-index.md
+++ b/adrs/01002-match-sections-in-order-not-by-index.md
@@ -79,10 +79,13 @@ repository's own `Sample` has `Setup` followed by `Usage`. A greedy first slot
 consumed both, then reported `Usage` missing. `repeat` is therefore a new
 key rather than the default, and only genuinely repeated placeholders set it.
 
-**A lone mismatch stays a mismatch.** A required anchored rule may match nothing
-anywhere while the section at the cursor is wanted by no later rule. The rule is
-then paired with that section anyway, and the heading rule reports
-`Expected title "X", but found "Y"`. The commonest error in the tool's history is
+**A lone mismatch stays a mismatch.** The rule is paired with that section
+anyway when two things hold:
+
+- A required anchored rule matches nothing anywhere.
+- No later rule wants the section at the cursor.
+
+The heading rule then reports `Expected title "X", but found "Y"`. The commonest error in the tool's history is
 one section with one wrong heading. Without this it would have degraded into
 `missing_section` plus `unexpected_section`, leaving the reader to work out that
 they are the same problem.

--- a/adrs/01003-remove-the-language-model-and-be-deterministic.md
+++ b/adrs/01003-remove-the-language-model-and-be-deterministic.md
@@ -55,10 +55,10 @@ Deleted: `src/rules/instructionValidator.js`, `src/util/preloadModel.js`,
 `src/util/tempDir.js`, the `node-llama-cpp` dependency, the `postinstall` and
 `clean` scripts, and `DOC_STRUCTURE_LINT_PRELOAD` from the package and from CI.
 
-`instructions:` is rejected by `src/schemas/template.json` rather than ignored.
-The loader turns that rejection into a message naming the offending template
-path, and prints the equivalent `moose-docevals` eval. The author's own
-instruction text is carried across:
+`instructions:` is rejected rather than ignored, by both the schema and the
+loader. `validateTemplateFile` finds it first and throws, so the message names
+the offending template path and prints the equivalent `moose-docevals` eval.
+The author's own instruction text is carried across:
 
 ```
 templates.yaml: "templates.how-to.sections.title" uses `instructions`, which
@@ -109,7 +109,7 @@ surface of the install.
 
 ### Confirmation
 
-`grep -ri "llama|preloadModel|tempDir|DOC_STRUCTURE_LINT_PRELOAD"` over `src/`,
+`grep -Eri "llama|preloadModel|tempDir|DOC_STRUCTURE_LINT_PRELOAD"` over `src/`,
 `package.json`, and the workflow returns nothing.
 
 The `instructions:` rejection is pinned in `test/unit/template-registry.test.ts`.

--- a/adrs/01003-remove-the-language-model-and-be-deterministic.md
+++ b/adrs/01003-remove-the-language-model-and-be-deterministic.md
@@ -9,26 +9,26 @@ decision-makers: [hawkeyexl]
 ## Context and Problem Statement
 
 The `instructions:` key let a template attach natural-language requirements to a
-section — "Must mention the intent of the document" — and `instructionValidator`
-evaluated them by running **Llama 3.2 3B locally**, through `node-llama-cpp`,
-against a JSON-schema grammar that forced a pass/fail verdict.
+section, such as "Must mention the intent of the document".
+`instructionValidator` evaluated them by running **Llama 3.2 3B locally**,
+through `node-llama-cpp`. A JSON-schema grammar forced a pass/fail verdict.
 
 The cost was not subtle. A `postinstall` script downloaded roughly 2 GB of model
-weights into a temp directory on every install, gated by a
-`DOC_STRUCTURE_LINT_PRELOAD` environment variable that CI had to set. A model
+weights into a temp directory on every install. A `DOC_STRUCTURE_LINT_PRELOAD`
+environment variable gated it, and CI had to set that variable. A model
 context and chat session were created, and the model reloaded from disk, **once
-per section per run**. And the answer was a sample from a 3B model: the same
-document and the same template could pass and then fail, so the tool could not be
-a gate.
+per section per run**. And the answer was a sample from a 3B model. The same
+document and the same template could pass and then fail, so the tool could not
+be a gate.
 
-It was also the wrong tool in the wrong repository. This is one of a family —
-`moose-meta` validates frontmatter against JSON Schema, `moose-kg` derives graphs,
-`moose-docevals` judges prose with an LLM behind a provider abstraction and a
-consensus/confidence layer, `moose-tracevals` does the same for agent traces.
-`moose-docevals` already treats this tool as a deterministic *grader* it invokes
-(`tool:doc-structure-lint`). Two tools in one family both making AI judgments,
-one of them with a bundled 3B model and no confidence gating, is a duplicated and
-strictly worse capability.
+It was also the wrong tool in the wrong repository. This is one of a family.
+`moose-meta` validates frontmatter against JSON Schema and `moose-kg` derives
+graphs. `moose-docevals` judges prose with an LLM behind a provider abstraction
+and a consensus/confidence layer. `moose-tracevals` does the same for agent
+traces. `moose-docevals` already treats this tool as a deterministic *grader* it
+invokes (`tool:doc-structure-lint`). Two tools in one family both making AI
+judgments is a duplicated and strictly worse capability. One of them bundled a
+3B model with no confidence gating.
 
 ## Decision Drivers
 
@@ -49,16 +49,16 @@ strictly worse capability.
 
 ## Decision Outcome
 
-Chosen option: **remove it, and reject `instructions:` loudly.**
+The chosen option is to **remove it, and reject `instructions:` loudly.**
 
 Deleted: `src/rules/instructionValidator.js`, `src/util/preloadModel.js`,
 `src/util/tempDir.js`, the `node-llama-cpp` dependency, the `postinstall` and
 `clean` scripts, and `DOC_STRUCTURE_LINT_PRELOAD` from the package and from CI.
 
-`instructions:` is rejected by `src/schemas/template.json` rather than ignored,
-and the loader turns that rejection into a message that names the offending
-template path and prints the equivalent `moose-docevals` eval, with the author's
-own instruction text carried across:
+`instructions:` is rejected by `src/schemas/template.json` rather than ignored.
+The loader turns that rejection into a message naming the offending template
+path, and prints the equivalent `moose-docevals` eval. The author's own
+instruction text is carried across:
 
 ```
 templates.yaml: "templates.how-to.sections.title" uses `instructions`, which
@@ -73,15 +73,19 @@ a moose-docevals assertion eval in moose.config.yaml:
 ```
 
 Removing the model also made the whole validator **synchronous**. `validateSection`
-was `async` only to await the model; with it gone, matching and every rule are
+was `async` only to await the model. With it gone, matching and every rule are
 ordinary function calls, and the recursion through subsections loses its
 `await`-in-a-loop.
 
 Three other dependencies went with it, all replaced by the platform or by the
-family: `axios` (Node 24 has `fetch`, which `docmeta`'s registry already uses),
-`crypto` (an npm shim of a Node builtin), and `uuid` (the parser now identifies
-sections by slug, as `moose-kg` does). Together with `node-llama-cpp`, that is the
-entire native-code and network surface of the install.
+family:
+
+- `axios`, because Node 24 has `fetch`, which `docmeta`'s registry already uses.
+- `crypto`, an npm shim of a Node builtin.
+- `uuid`, because the parser now identifies sections by slug, as `moose-kg` does.
+
+Together with `node-llama-cpp`, that is the entire native-code and network
+surface of the install.
 
 ### Consequences
 
@@ -89,9 +93,9 @@ entire native-code and network surface of the install.
   findings, which is what a CI gate requires.
 - Good, because install is a plain JavaScript dependency tree: no native build,
   no model download, no `postinstall`.
-- Good, because the family's boundary is now stated rather than implied —
-  moose-lint answers "does this page have the shape it claims", moose-docevals
-  answers "is the prose any good".
+- Good, because the family's boundary is now stated rather than implied.
+  moose-lint answers "does this page have the shape it claims", and
+  moose-docevals answers "is the prose any good".
 - Good, because a run costs milliseconds instead of a model load per section.
 - Bad, because a real capability is gone from this tool, and templates using it
   break at load time rather than degrading. That is deliberate: silence would
@@ -100,7 +104,7 @@ entire native-code and network surface of the install.
   nothing writes it to `moose.config.yaml`. An `eject-instructions` command was
   considered and deferred; it can be added if real templates make it worth it.
 - Neutral, because `moose-docevals`' `tool:doc-structure-lint` adapter is
-  unaffected by this change specifically — it parses the JSON reporter, whose
+  unaffected by this change specifically. It parses the JSON reporter, whose
   shape is unchanged. It does need updating for the rename, separately.
 
 ### Confirmation
@@ -108,9 +112,9 @@ entire native-code and network surface of the install.
 `grep -ri "llama|preloadModel|tempDir|DOC_STRUCTURE_LINT_PRELOAD"` over `src/`,
 `package.json`, and the workflow returns nothing.
 
-The `instructions:` rejection is pinned in `test/unit/template-registry.test.ts`,
-and was exercised end to end against this repository's own `templates.yaml`,
-which carried two `instructions:` blocks: the CLI exited 2 with the migration
+The `instructions:` rejection is pinned in `test/unit/template-registry.test.ts`.
+It was also exercised end to end against this repository's own `templates.yaml`,
+which carried two `instructions:` blocks. The CLI exited 2 with the migration
 message before the blocks were removed, and exits 0 after.
 
 ## Pros and Cons of the Options
@@ -124,8 +128,8 @@ message before the blocks were removed, and exits 0 after.
 ### Remove it silently, ignoring the key
 
 - Good, because no template stops loading.
-- Bad, because a rule the author believes is enforced quietly is not — the worst
-  outcome available for a tool whose job is enforcement.
+- Bad, because a rule the author believes is enforced quietly is not. That is
+  the worst outcome available for a tool whose job is enforcement.
 
 ### Keep it behind an opt-in flag, on `@hawkeyexl/inference`
 

--- a/adrs/01003-remove-the-language-model-and-be-deterministic.md
+++ b/adrs/01003-remove-the-language-model-and-be-deterministic.md
@@ -27,8 +27,8 @@ graphs. `moose-docevals` judges prose with an LLM behind a provider abstraction
 and a consensus/confidence layer. `moose-tracevals` does the same for agent
 traces. `moose-docevals` already treats this tool as a deterministic *grader* it
 invokes (`tool:doc-structure-lint`). Two tools in one family both making AI
-judgments is a duplicated and strictly worse capability. One of them bundled a
-3B model with no confidence gating.
+judgments is a duplicated capability. This one was strictly worse: a bundled 3B
+model with no confidence gating.
 
 ## Decision Drivers
 

--- a/adrs/01004-route-templates-by-the-type-frontmatter-key.md
+++ b/adrs/01004-route-templates-by-the-type-frontmatter-key.md
@@ -10,7 +10,7 @@ decision-makers: [hawkeyexl]
 
 `--template` applied one template to every file in the run. That is the wrong
 unit. A `docs/` tree is a mix of how-tos, references, concepts, and tutorials,
-and one template cannot describe all of them — so checking a docset meant one
+and one template cannot describe all of them. So checking a docset meant one
 invocation per doctype, each with a glob naming where that doctype lives:
 
 ```yaml
@@ -21,14 +21,14 @@ invocation per doctype, each with a glob naming where that doctype lives:
 
 That is a second classification of the docset, maintained by hand, in a file
 nobody opens when they add a page. It drifts, and it drifts in the worst
-direction: a how-to written into `docs/concepts/` is checked against the concept
-template and reported as broken, and a page written into a directory no glob
-covers is checked by nothing at all and reported as nothing at all. The run is
-green either way.
+direction. A how-to written into `docs/concepts/` is checked against the concept
+template and reported as broken. A page written into a directory no glob covers
+is checked by nothing at all, and reported as nothing at all. The run is green
+either way.
 
 Meanwhile the classification already exists. A typed page says what it is in its
-own frontmatter — `type: how-to` — and it is the same key `moose-meta`'s OKF
-schema requires, that Diataxis names, that TGDP's frontmatter carries, and that
+own frontmatter, as `type: how-to`. It is the same key `moose-meta`'s OKF schema
+requires, that Diataxis names, that TGDP's frontmatter carries, and that
 `moose-kg` reads to build its graph. It is written by the person writing the
 page, in the page, and it is already validated by a sibling tool. Nothing was
 using it.
@@ -38,7 +38,7 @@ using it.
 - The doctype of a page is a property of the page, not of the command line.
 - One invocation should check a whole tree, and adding a page should require no
   change to CI.
-- There must still be a way to say "not this page" and "not this repo" — a
+- There must still be a way to say "not this page" and "not this repo". A
   routing scheme with no escape hatch gets abandoned at the first exception.
 - "Why was this page linted with *that*?" must be answerable without reading the
   source, because a wrong answer is invisible: the page still passes.
@@ -57,9 +57,9 @@ using it.
 
 ## Decision Outcome
 
-Chosen option: **a precedence chain ending in the page's `type`**, in
+The chosen option is **a precedence chain ending in the page's `type`**, in
 `src/core/resolve-template.ts`, ordered as `docmeta`'s `resolveSchemaSet` orders
-its own: an explicit instruction beats a per-page declaration, which beats repo
+its own. An explicit instruction beats a per-page declaration. That beats repo
 policy, which beats the page's own vocabulary, which beats a blanket default.
 
 | | stage | what it means |
@@ -71,40 +71,40 @@ policy, which beats the page's own vocabulary, which beats a blanket default.
 | 5 | a config default | what to assume when a page says nothing |
 
 `$template` sits **above** the override glob deliberately. A page that names its
-own template did so on purpose, one page at a time; a glob included it by
+own template did so on purpose, one page at a time. A glob included it by
 accident of where it happens to live. The more specific statement wins, and the
 more specific statement is the one somebody had to write by hand.
 
-Stages 3 and 5 are read but nothing writes them yet — `moose.config.yaml` is a
-later change. They are in the chain now rather than later because retrofitting a
-stage into a precedence order changes the meaning of every configuration already
-written against it, and the ordering argument is much easier to make before
-anyone depends on the answer.
+Stages 3 and 5 are read but nothing writes them yet, since `moose.config.yaml`
+is a later change. They are in the chain now because retrofitting a stage into a
+precedence order changes the meaning of every configuration already written
+against it. The ordering argument is much easier to make before anyone depends
+on the answer.
 
 Every stage appends a `ResolutionStep` whether or not it fired, including the
 ones with nothing to say, and `--explain` prints the whole record and lints
-nothing. Printing the silent stages is the point: a surprising route is almost
-always a stage the reader forgot applies — a stray `$template`, a glob matching
-more than intended — and a report showing only the winner would hide exactly
+nothing. Printing the silent stages is the point. A surprising route is almost
+always a stage the reader forgot applies, such as a stray `$template` or a glob
+matching more than intended. A report showing only the winner would hide exactly
 what is being looked for. `--explain` exits `0` however the docs look, because it
 answers a question about configuration and not about the documents.
 
 **A missing `type` and an unknown one are treated differently, on purpose.**
 
-A page with no `type` that reaches the end of the chain is **skipped**: counted
-apart from passes and failures, not failing the run, not stopping its
-neighbours. An untyped page is `moose-meta`'s complaint — its OKF schema already
-requires `type` — and duplicating that check here would mean adopting this tool
-requires typing every page first. Skipping is what lets a repo that has typed
-three pages out of two hundred point `moose-lint` at the whole tree today and
-get three pages checked.
+A page with no `type` that reaches the end of the chain is **skipped**. It is
+counted apart from passes and failures, it does not fail the run, and it does
+not stop its neighbours. An untyped page is `moose-meta`'s complaint, because
+its OKF schema already requires `type`. Duplicating that check here would mean
+adopting this tool requires typing every page first. Skipping is what lets a
+repo point `moose-lint` at its whole tree today, with three pages typed out of
+two hundred. Three pages then get checked.
 
-A page whose `type` resolves to **no template** is an **error**: exit `1`, with
-near misses named from a bounded edit-distance pass over the known doctypes
+A page whose `type` resolves to **no template** is an **error**. It exits `1`,
+with near misses named from a bounded edit-distance pass over the known doctypes
 (`how-two` suggests `how-to`). That page's author believes it is being checked.
 Skipping it would mean a rule they wrote is not enforced and nobody ever finds
-out — the same failure mode ADR 01003 rejected for `instructions:`, and the one
-outcome worse than a false positive.
+out. That is the failure mode ADR 01003 rejected for `instructions:`, and the
+one outcome worse than a false positive.
 
 ### Consequences
 
@@ -112,40 +112,49 @@ outcome worse than a false positive.
   changes no configuration anywhere.
 - Good, because the classification lives next to the content it classifies and
   is maintained by whoever changes the content.
-- Good, because it composes with the family rather than duplicating it: the key
+- Good, because it composes with the family rather than duplicating it. The key
   is the one `moose-meta` validates and `moose-kg` reads, so a repo that has
   adopted either gets routing for free.
-- Good, because `--explain` makes the decision auditable, which matters more
-  here than for most flags — routing to the wrong template usually produces a
+- Good, because `--explain` makes the decision auditable. That matters more here
+  than for most flags, since routing to the wrong template usually produces a
   clean run, not a wrong one.
 - Bad, because a repo that does not type its pages gets nothing from this and
   sees a wall of skips. The fix is `moose-meta`, not this tool, but it does mean
   the headline feature is inert on an untyped docset.
 - Bad, because a run in which *every* page was skipped exits `0` and reports
   "0 files checked". That is the honest summary of what happened, but it reads
-  like a clean bill of health, and an `--exclude` typo and a docset with no
+  like a clean bill of health. An `--exclude` typo and a docset with no
   frontmatter look identical in CI.
 - Bad, because five stages is more than anyone wants to hold in their head, and
   two of them currently do nothing. `--explain` exists partly to pay that back.
 - Neutral, because `--template` is unchanged and still wins outright, so every
-  existing invocation — including `moose-docevals`' adapter — keeps working with
-  no edit. It stops being *required*, which is the whole change.
+  existing invocation keeps working with no edit, including `moose-docevals`'
+  adapter. It stops being *required*, which is the whole change.
 
 ### Confirmation
 
-`test/unit/resolve-template.test.ts` pins the chain in isolation: each stage's
-precedence over the ones below it, the first-match-wins rule for override globs,
-glob matching against a Windows path, non-string `type`/`$template` values being
-ignored, the two causes and their near-miss suggestions, and the resolution
-record — every consulted stage, in order, stopping at the one that decided.
+`test/unit/resolve-template.test.ts` pins the chain in isolation:
+
+- Each stage's precedence over the ones below it.
+- The first-match-wins rule for override globs, and glob matching against a
+  Windows path.
+- Non-string `type`/`$template` values being ignored.
+- The two causes and their near-miss suggestions.
+- The resolution record, which is every consulted stage, in order, stopping at
+  the one that decided.
 
 `test/integration/routing.test.ts` pins what the chain is *for*, against real
-files: a directory of mixed doctypes with each page checked against the template
-for what it claims to be, a how-to missing its `Overview` reported as one
-finding rather than the cascade a blanket template would produce, an untyped
-page skipped without failing the run or stopping its typed neighbours, a typo'd
-type failing with the suggestion, `--template` and `$template` overriding a
-page's own type, and `--explain` recording the chain without linting.
+files:
+
+- A directory of mixed doctypes, with each page checked against the template for
+  what it claims to be.
+- A how-to missing its `Overview`, reported as one finding rather than the
+  cascade a blanket template would produce.
+- An untyped page skipped without failing the run or stopping its typed
+  neighbours.
+- A typo'd type failing with the suggestion.
+- `--template` and `$template` overriding a page's own type.
+- `--explain` recording the chain without linting.
 
 ## Pros and Cons of the Options
 
@@ -155,24 +164,24 @@ page's own type, and `--explain` recording the chain without linting.
   hatch above it is written in the place the exception actually lives.
 - Good, because it is the shape `docmeta` already uses, so someone who knows one
   tool's resolution order knows the other's.
-- Bad, because a surprising result needs `--explain` to unpick, which is a
-  second command to learn about a decision the user did not know was being made.
+- Bad, because a surprising result needs `--explain` to unpick. That is a second
+  command to learn about a decision the user did not know was being made.
 
 ### `type` and nothing else
 
 - Good, because there is exactly one answer to "which template?", and nothing to
   explain.
 - Bad, because there is then no way to check one page against a different
-  template without editing the page, and no way to run the tool at all against a
-  docset that is not yet typed.
+  template without editing the page. There is also no way to run the tool at all
+  against a docset that is not yet typed.
 - Bad, because it removes `--template`, which `moose-docevals` invokes.
 
 ### Route by file path convention
 
 - Good, because it needs no frontmatter, so it works on any docset today.
-- Bad, because it invents a second classification — the directory layout — that
-  has to agree with the `type` the page already declares, and nothing checks
-  that they agree. This is the problem the per-doctype globs already had.
+- Bad, because it invents a second classification, the directory layout, that
+  has to agree with the `type` the page already declares. Nothing checks that
+  they agree. This is the problem the per-doctype globs already had.
 - Bad, because moving a file would change what it is checked against. Nobody
   would choose that as a property of their documentation.
 
@@ -180,4 +189,4 @@ page's own type, and `--explain` recording the chain without linting.
 
 - Good, because it costs nothing to decide, and it is what exists.
 - Bad, because every objection in the problem statement stands, and the failure
-  mode is silence: a page no glob covers is never checked, and the run is green.
+  mode is silence. A page no glob covers is never checked, and the run is green.

--- a/adrs/01005-ship-tgdp-structure-templates-without-demoting-user-templates.md
+++ b/adrs/01005-ship-tgdp-structure-templates-without-demoting-user-templates.md
@@ -11,9 +11,9 @@ decision-makers: [hawkeyexl]
 ADR 01004 made a page's `type` route it to a template. That is only useful if a
 template for the doctype exists, and out of the box none did. So the first task
 for every adopter was to write, from nothing, an answer to "what sections should
-a how-to have?" — the hardest part of adopting the tool, and the part where an
-individual guess is least valuable, because the documentation community has
-already answered it in public.
+a how-to have?" That is the hardest part of adopting the tool. It is also the
+part where an individual guess is least valuable, because the documentation
+community has already answered it in public.
 
 [The Good Docs Project](https://gitlab.com/tgdp/templates) publishes templates
 for exactly these doctypes: how-to, tutorial, reference, concept,
@@ -26,9 +26,9 @@ Shipping templates has two failure modes worth naming before choosing to do it.
 
 The first is that a built-in which is awkward to override stops being a default
 and becomes a house style imposed by a linter. Documentation teams have opinions
-about their doctypes and most of those opinions are legitimate: TGDP's how-to
-carries a `See also` section and does not mark it optional, so a template derived
-faithfully requires one — and plenty of correct how-tos have none.
+about their doctypes, and most of those opinions are legitimate. TGDP's how-to
+carries a `See also` section and does not mark it optional, so a template
+derived faithfully requires one. Plenty of correct how-tos have none.
 
 The second is that "derived from The Good Docs Project" is a *claim*. A YAML file
 in `src/` with that sentence in a comment is a comment. Nothing stops it drifting
@@ -43,7 +43,7 @@ version number nobody bumps is worth.
 - A template the user wrote must beat a built-in, without a config file and
   without a flag beyond naming the file.
 - Disagreeing with one rule in a built-in must not require copying the whole
-  thing, because a copy inherits none of the built-in's later corrections.
+  thing. A copy inherits none of the built-in's later corrections.
 - The provenance claim must be executable, and the pin's staleness must be
   visible without anyone remembering to look.
 - Deriving a structural template from a prose template is a judgement call per
@@ -60,112 +60,120 @@ version number nobody bumps is worth.
 
 ## Decision Outcome
 
-Chosen option: **derive seven templates, pin them at TGDP v1.6.0 ("Iron"),
-round-trip test each against the published template it came from, and make user
-templates outrank built-ins in the doctype index.**
+The chosen option is to **derive seven templates and pin them at TGDP v1.6.0
+("Iron")**. Each is round-trip tested against the published template it came
+from, and **user templates outrank built-ins in the doctype index.**
 
 **Built-ins are registered through a manifest, not hardcoded.**
 `src/templates/tgdp/manifest.json` carries each entry's id, YAML file, title,
 the doctypes it serves, and the upstream `source` it was derived from. The id
-encodes the pin — `tgdp:how-to:1.6` — so the version in a ref is a statement
+encodes the pin, as in `tgdp:how-to:1.6`, so the version in a ref is a statement
 about which upstream revision it mirrors. `tgdp:concept:1.6` serves `explanation`
 as well as `concept`, because Diataxis and TGDP name the same shape differently.
 
 **The round-trip test is what makes "publicly vetted" checkable.**
-`test/integration/tgdp.test.ts` lints TGDP's own `template_<slug>.md` — vendored
-verbatim under `test/fixtures/tgdp/` — against the template derived from it, and
-requires zero findings. Where the two disagree, **upstream is right**: the
-fixture is the authority and the template is the thing under test, which is the
-reverse of the usual fixture relationship and the only arrangement in which the
-claim means anything. The suite is driven by the manifest, so a built-in cannot
-be registered without acquiring this test, and cannot acquire it without a
-vendored source.
+`test/integration/tgdp.test.ts` lints TGDP's own `template_<slug>.md`, vendored
+verbatim under `test/fixtures/tgdp/`, against the template derived from it, and
+requires zero findings. Where the two disagree, **upstream is right**. The
+fixture is the authority and the template is the thing under test. That is the
+reverse of the usual fixture relationship, and the only arrangement in which the
+claim means anything. The suite is driven by the manifest. A built-in cannot be
+registered without acquiring this test, and cannot acquire it without a vendored
+source.
 
-**The pin is watched, not gated.** `npm run check:tgdp-pin` asks GitLab's release
-API whether upstream has moved and prints what moving the pin would involve —
-re-vendor each source, run the suite, fix wherever a built-in no longer matches,
-bump the `pin` and every id. Upstream moving does not make the pinned templates
-wrong, it makes them old, so it is a report; `--strict` exits non-zero for a job
-whose purpose is to nag.
+**The pin is watched, not gated.** `npm run check:tgdp-pin` asks GitLab's
+release API whether upstream has moved. It then prints what moving the pin would
+involve:
+
+- Re-vendor each source and run the suite.
+- Fix wherever a built-in no longer matches.
+- Bump the `pin` and every id.
+
+Upstream moving does not make the pinned templates wrong, it makes them old, so
+it is a report. `--strict` exits non-zero for a job whose purpose is to nag.
 
 **User templates outrank built-ins by construction, not by policy.**
 `buildTypeIndex` inserts the built-ins first and user templates second into one
 map keyed by doctype, so a later entry simply overwrites an earlier one.
 Overriding the how-to doctype for a repo is one file with `types: [how-to]` in
 it. There is no "disable the built-ins" switch because there is nothing to
-disable: claiming the doctype *is* the override, and a doctype a user file does
+disable. Claiming the doctype *is* the override, and a doctype a user file does
 not claim quietly stays on its built-in.
 
 **`extends` is the graduated form of the same thing.** `resolveExtends` merges
-through `sections` by key, recursively, all the way down, while every other key
-the child sets replaces the parent's outright — a section's own rules are units,
-but `sections` is a container, and replacing it wholesale would mean tightening
-one nested rule silently discarded every sibling the parent declared. That is
+through `sections` by key, recursively, all the way down. Every other key the
+child sets replaces the parent's outright. A section's own rules are units, but
+`sections` is a container. Replacing it wholesale would mean tightening one
+nested rule silently discarded every sibling the parent declared. That is
 what lets `templates.yaml`'s `house-how-to` be four lines: `extends:
 tgdp:how-to:1.6`, `types: [how-to]`, and `see also: {required: false}`. Overview,
 Before you start, and the repeating task sections are all still checked.
 
 **What the derived templates assert is order and membership, not volume.**
-Content minimums are set only where the doctype genuinely requires prose — a
-how-to `Overview` with no paragraph is not a how-to — and are absent almost
-everywhere else. The reason is concrete: the parser models paragraphs, code
-blocks, and lists but not tables (ADR 01001), and reference entries, README
+Content minimums are set only where the doctype genuinely requires prose, since
+a how-to `Overview` with no paragraph is not a how-to. They are absent almost
+everywhere else. The reason is concrete. The parser models paragraphs, code
+blocks, and lists but not tables (ADR 01001). Reference entries, README
 dependency sections, and release-note categories are as often tables as lists.
-A `lists: {min: 1}` there would fail pages a reader would call correct. Where
-upstream ships an authoring marker in the literal heading — `## (Optional)
-Commands`, `## Optional: Deprecation notice` — the pattern accepts the heading
-both with the marker and without it, which is what lets upstream's own file lint
-clean against the template derived from it.
+A `lists: {min: 1}` there would fail pages a reader would call correct.
+Upstream sometimes ships an authoring marker in the literal heading, such as
+`## (Optional) Commands` or `## Optional: Deprecation notice`. The pattern then
+accepts the heading both with the marker and without it. That is what lets
+upstream's own file lint clean against the template derived from it.
 
 ### Consequences
 
 - Good, because a typed docset is checked by `moose-lint docs/` and nothing
   else: no template to write, no flag, no config.
 - Good, because the provenance claim is a test rather than a comment, and it
-  fails in the right direction — if upstream's template does not pass ours,
-  ours is wrong.
+  fails in the right direction. If upstream's template does not pass ours, ours
+  is wrong.
 - Good, because the version in an id is kept honest by `check:tgdp-pin` rather
   than by anyone remembering.
-- Good, because disagreement is cheap and graduated: relax one rule with
+- Good, because disagreement is cheap and graduated. Relax one rule with
   `extends`, or claim the doctype outright with `types:`, and neither needs a
   config file.
 - Bad, because deriving a structural template from a prose one is a judgement
   call per section and some of ours are arguable. Every one is argued in a
   `description:` in the YAML, which is mitigation, not a defence.
-- Bad, because the built-ins model upstream's H1 as their top-level rule, so a
+- Bad, because the built-ins model upstream's H1 as their top-level rule. A
   docset whose page titles live in frontmatter and whose bodies start at `##`
-  matches none of them — and fails with a cascade of missing and unexpected
+  matches none of them. It fails with a cascade of missing and unexpected
   sections rather than one legible finding. Sites are commonly built this way.
   The escape (`extends` and replace the top-level rule) is not discoverable.
 
   *Resolved by [ADR 01006](01006-take-the-h1-from-frontmatter-when-the-body-has-none.md),
-  which was taken after this one.* A first-class affordance was deferred here
-  for want of somewhere honest to put it in the DSL; 01006's answer was that it
-  does not belong in the DSL at all, but in the parsers, which prepend a
+  which was taken after this one.*
+
+  A first-class affordance was deferred here for want of somewhere honest to put
+  it in the DSL. 01006's answer was that it
+  does not belong in the DSL at all, but in the parsers. They prepend a
   synthetic H1 positioned on the metadata that carries the title. The built-ins
-  are unchanged — they still model the H1 as their top-level rule — and now
-  match these pages because the tree they are matched against is the document as
-  a reader sees it rendered.
+  are unchanged and still model the H1 as their top-level rule. They now match
+  these pages because the tree they are matched against is the document as a
+  reader sees it rendered.
 - Bad, because seven derived artifacts are seven files to re-derive whenever the
-  pin moves, and the round-trip test says *that* one broke, not what to change
-  in it.
+  pin moves. The round-trip test says *that* one broke, not what to change in
+  it.
 - Neutral, because troubleshooting's causes and solutions are matched by a single
   repeating rule accepting either word. Upstream alternates them and the DSL
-  cannot repeat a *pair* of rules, so a page that grouped all its causes before
+  cannot repeat a *pair* of rules. So a page that grouped all its causes before
   all its solutions also passes. It is the only place a built-in is structurally
   looser than the doctype it mirrors, and it is recorded in the template.
 
 ### Confirmation
 
-`test/integration/tgdp.test.ts` is manifest-driven and pins four things: every
-manifest entry is registered, every entry serves at least one doctype, no two
-built-ins claim the same doctype, and every entry lints its vendored upstream
-source with zero findings.
+`test/integration/tgdp.test.ts` is manifest-driven and pins four things:
+
+- Every manifest entry is registered.
+- Every entry serves at least one doctype.
+- No two built-ins claim the same doctype.
+- Every entry lints its vendored upstream source with zero findings.
 
 `test/integration/routing.test.ts` pins the precedence that keeps user templates
-first-class: a template declaring `types: [how-to]` beats `tgdp:how-to:1.6` with
-no config and no flag beyond `--templates`, and a doctype it does not declare
-stays on the built-in.
+first-class. A template declaring `types: [how-to]` beats `tgdp:how-to:1.6` with
+no config and no flag beyond `--templates`. A doctype it does not declare stays
+on the built-in.
 
 `test/integration/repo-templates.test.ts` pins this repository's own
 `templates.yaml`: that `api-operation-guide` and `house-how-to` declare the
@@ -188,26 +196,26 @@ the rest of `tgdp:how-to:1.6`.
 
 - Good, because there is nothing to maintain and no opinion imposed on anyone.
 - Bad, because routing by `type` is then inert until the adopter writes a
-  template per doctype — the hardest part of adoption, and the part a published,
-  reviewed answer already exists for.
+  template per doctype. That is the hardest part of adoption, and the part a
+  published, reviewed answer already exists for.
 - Bad, because everyone's first how-to template would be a private guess at a
-  public question, and none of them would be checkable against anything.
+  public question. None of them would be checkable against anything.
 
 ### Vendor TGDP's Markdown and derive templates at runtime
 
 - Good, because there is one artifact and it cannot drift from upstream.
 - Bad, because "this section is optional" is stated in upstream's prose as
-  `{This section is optional}` and in its heading text as `(Optional)`, and
-  turning that into a rule is inference. A linter whose rules are inferred from
+  `{This section is optional}` and in its heading text as `(Optional)`. Turning
+  that into a rule is inference, and a linter whose rules are inferred from
   prose at run time is not one anybody can predict.
 - Bad, because every judgement now written into a `description:` would become a
-  heuristic, and a wrong heuristic cannot be fixed for one doctype without
-  changing the derivation for all seven.
+  heuristic. A wrong heuristic cannot be fixed for one doctype without changing
+  the derivation for all seven.
 
 ### Ship built-ins that win, with a config key to opt out
 
 - Good, because it makes the vetted templates the default in a stronger sense.
-- Bad, because "the linter has an opinion you must configure your way out of" is
-  how a tool becomes something teams route around rather than adopt.
+- Bad, because a linter with an opinion you must configure your way out of
+  becomes something teams route around rather than adopt.
 - Bad, because it makes a config file necessary for the commonest customization
   there is, when the point of `types:` is that overriding takes none.

--- a/adrs/01006-take-the-h1-from-frontmatter-when-the-body-has-none.md
+++ b/adrs/01006-take-the-h1-from-frontmatter-when-the-body-has-none.md
@@ -9,15 +9,15 @@ decision-makers: [hawkeyexl]
 ## Context and Problem Statement
 
 Every built-in doctype template models the page title as its outermost rule,
-because that is how the published templates are written — TGDP's how-to opens
-`# Title`, its sections hanging beneath.
+because that is how the published templates are written. TGDP's how-to opens
+`# Title`, with its sections hanging beneath.
 
 Docusaurus, Hugo, and Starlight all render the page title from frontmatter. On
 those sites a page carries `title:` in its front matter and its body starts at
-`##`. Read literally, such a page has **no top-level section at all**: the `##`
-headings become roots, the template's outermost rule matches the first of them,
-and every rule beneath it looks for sections that are actually its siblings. One
-page produced five findings, none of which named a real problem:
+`##`. Read literally, such a page has **no top-level section at all**. The `##`
+headings become roots and the template's outermost rule matches the first of
+them. Every rule beneath it then looks for sections that are actually its
+siblings. One page produced five findings, none of which named a real problem:
 
 ```text
 ✗ headless.md
@@ -29,10 +29,10 @@ page produced five findings, none of which named a real problem:
 ```
 
 This is not a rare shape. It is the default for three of the most widely used
-documentation site generators, and the README's first draft had to tell those
-users the built-in templates "are not for you as shipped" — which would have
-made the tool's headline feature inapplicable to a large fraction of the docsets
-it is meant to check.
+documentation site generators. The README's first draft had to tell those users
+the built-in templates "are not for you as shipped". That would have made the
+tool's headline feature inapplicable to a large fraction of the docsets it is
+meant to check.
 
 The page is not malformed. Its title is simply not written where a naive reading
 looks for it.
@@ -56,31 +56,31 @@ looks for it.
 
 ## Decision Outcome
 
-Chosen option: **synthesize an H1 from the frontmatter `title`.**
+The chosen option is to **synthesize an H1 from the frontmatter `title`.**
 
-When a page carries a non-empty string `title` in its front matter and its body
-contains no level-1 heading, the parser prepends a synthetic heading block before
-sectionizing. Everything downstream — matching, rules, reporting — then sees the
-document the way a reader sees it rendered, and needs no knowledge of any of
-this.
+A page may carry a non-empty string `title` in its front matter while its body
+contains no level-1 heading. The parser then prepends a synthetic heading block
+before sectionizing. Everything downstream, including matching, rules, and
+reporting, sees the document the way a reader sees it rendered. None of it needs
+any knowledge of this.
 
-The synthetic heading is **positioned on the front matter block**, so a finding
-about the title points at the lines that carry it rather than at an invented
-location or at line 1 by default.
+The synthetic heading is **positioned on the front matter block**. A finding
+about the title points at the lines that carry it. It does not point at an
+invented location, or at line 1 by default.
 
 Three conditions are all required, and each excludes a case where synthesizing
 would be wrong:
 
 - **A string `title`, non-empty.** A list or a number is not a title.
 - **No level-1 heading in the body.** Prepending one where a real H1 exists would
-  nest the real title inside a synthetic parent — a different document.
+  nest the real title inside a synthetic parent, which is a different document.
 - **Front matter actually present**, so there is a position to anchor on.
 
-A page with neither an H1 nor a frontmatter `title` keeps the existing behavior:
-its content before the first heading becomes the implicit lead section at level
-0. That page has no top-level section for a doctype template to match and will
-report as much, which is correct — it is a page a reader would also struggle to
-name.
+A page with neither an H1 nor a frontmatter `title` keeps the existing behavior.
+Its content before the first heading becomes the implicit lead section at level
+0. That page has no top-level section for a doctype template to match, and will
+report as much. That is correct, because a reader would also struggle to name
+such a page.
 
 ### Consequences
 
@@ -93,7 +93,7 @@ name.
   where the author would go to fix them.
 - Bad, because the section tree no longer corresponds one-to-one with headings
   in the source. A `SectionNode` may exist that nothing in the body wrote, and
-  anyone reading the tree — a future `moose-kg` integration, say — has to know
+  anyone reading the tree, such as a future `moose-kg` integration, has to know
   that. `headingPosition` pointing into the front matter is the signal.
 - Bad, because `title` is now load-bearing in a tool that otherwise only reads
   `type` and `$template`. It is a de facto standard rather than one the family's
@@ -103,10 +103,10 @@ name.
 
 ### Confirmation
 
-`test/unit/parsers.test.ts` pins all five branches: the title becomes the
-top-level section; it is anchored at line 1, offset 0 (the front matter); a real
-H1 is not displaced; nothing is synthesized without a title; a non-string or
-empty title is ignored; and content before the first heading is carried into the
+`test/unit/parsers.test.ts` pins all five branches. The title becomes the
+top-level section, anchored at line 1, offset 0 (the front matter). A real H1 is
+not displaced. Nothing is synthesized without a title, and a non-string or empty
+title is ignored. Content before the first heading is carried into the
 synthesized section rather than stranded.
 
 `test/integration/repo-templates.test.ts` runs it against
@@ -131,17 +131,17 @@ lead section.
 ### Make the built-ins' top-level rule optional
 
 - Good, because it is a one-word change in seven files.
-- Bad, because it does not work: an optional rule that does not match is skipped,
-  so the `##` sections are then matched against the *title rule's siblings*,
-  which is a different misalignment rather than none.
+- Bad, because it does not work. An optional rule that does not match is
+  skipped, so the `##` sections are then matched against the *title rule's
+  siblings*. That is a different misalignment rather than none.
 - Bad, because it weakens the templates for every document that does have an H1.
 
 ### Match a template's top-level rule against the document root
 
-- Good, because it removes the special case entirely — the outermost rule would
+- Good, because it removes the special case entirely. The outermost rule would
   describe "the document" rather than "the H1 section".
 - Bad, because it makes the template DSL mean something different at the top
-  level than at every level below it, which is exactly the kind of positional
+  level than at every level below it. That is exactly the kind of positional
   special-casing [ADR 01002](01002-match-sections-in-order-not-by-index.md)
   removed from the matcher.
 - Bad, because it breaks templates that legitimately describe several top-level

--- a/adrs/01006-take-the-h1-from-frontmatter-when-the-body-has-none.md
+++ b/adrs/01006-take-the-h1-from-frontmatter-when-the-body-has-none.md
@@ -58,9 +58,11 @@ looks for it.
 
 The chosen option is to **synthesize an H1 from the frontmatter `title`.**
 
-A page may carry a non-empty string `title` in its front matter while its body
-contains no level-1 heading. The parser then prepends a synthetic heading block
-before sectionizing. Everything downstream, including matching, rules, and
+The parser prepends a synthetic heading block before sectionizing when two
+things hold:
+
+- The page carries a non-empty string `title` in its front matter.
+- Its body contains no level-1 heading. Everything downstream, including matching, rules, and
 reporting, sees the document the way a reader sees it rendered. None of it needs
 any knowledge of this.
 

--- a/adrs/01007-read-settings-from-a-lint-section-of-a-shared-moose-config.md
+++ b/adrs/01007-read-settings-from-a-lint-section-of-a-shared-moose-config.md
@@ -8,17 +8,17 @@ decision-makers: [hawkeyexl]
 
 ## Context and Problem Statement
 
-`moose-lint` had no configuration at all: every run restated its targets, its
+`moose-lint` had no configuration at all. Every run restated its targets, its
 excludes, and its template files on the command line. That is workable for one
-invocation and not for CI, where the same twelve flags get copied into a
-workflow file and drift from what developers run locally.
+invocation and not for CI. There the same twelve flags get copied into a
+workflow file, and drift from what developers run locally.
 
-The obvious fix — give the tool its own dotfile — is the one the family has
-already rejected. `moose-lint` is one of several tools routinely used in the same
-repository: `moose-meta` validates the frontmatter, `moose-docevals` judges the
-prose, `moose-kg` builds the graph. A project wiring up all of them would
-accumulate a dotfile per tool that nobody could see the relationship between,
-and the settings they share would have to be restated and kept in sync in each.
+The obvious fix is to give the tool its own dotfile, and the family has already
+rejected it. `moose-lint` is one of several tools routinely used in the same
+repository. `moose-meta` validates the frontmatter, `moose-docevals` judges the
+prose, and `moose-kg` builds the graph. A project wiring up all of them would
+accumulate a dotfile per tool that nobody could see the relationship between.
+The settings they share would have to be restated and kept in sync in each.
 
 `moose-tracevals` settled this in
 [its ADR 01009](https://github.com/hawkeyexl/agentevals), and `moose-docevals`
@@ -30,9 +30,9 @@ to follow, and what following costs a tool whose config arrives after its CLI.
 - One file per project, not one per tool, so shared settings are stated once.
 - A tool must never fail, warn, or otherwise care because a sibling tool's keys
   are in the file.
-- Validation must stay strict for the keys this tool owns — `additionalProperties:
-  false` at every level is what turns a typo into a loud failure rather than a
-  silent default.
+- Validation must stay strict for the keys this tool owns. Setting
+  `additionalProperties: false` at every level turns a typo into a loud failure
+  rather than a silent default.
 - The ways an author can lose a whole config must be reported, not defaulted
   through. A config that is silently ignored is worse than no config, because the
   author believes their settings are in force.
@@ -48,29 +48,29 @@ to follow, and what following costs a tool whose config arrives after its CLI.
 
 ## Decision Outcome
 
-Chosen option: **a single `moose.config.yaml`, read under `lint:`.**
+The chosen option is **a single `moose.config.yaml`, read under `lint:`.**
 
 The file root is a mapping of tool name to that tool's settings. `loadConfig()`
 reads the file, takes the `lint` value, and hands that to `parseConfig()`.
-Sibling keys are neither read nor validated — no registry of known tools, no
-coordination, no version coupling between the tools. `src/schemas/config.json`
+Sibling keys are neither read nor validated. There is no registry of known
+tools, no coordination, and no version coupling between the tools. `src/schemas/config.json`
 describes **the section**, so its strictness applies at every level below `lint:`
 and nowhere above it.
 
 Discovery walks up from the working directory to the repository root, so the tool
 behaves the same from a subdirectory as from the top. `-c/--config` names a file
-directly and skips discovery — and gets no filename sniffing, because users may
+directly and skips discovery. It gets no filename sniffing, because users may
 name an explicitly-passed file anything.
 
 **Config is loaded in the CLI, not in `runLint`.** The command core keeps taking
-everything it needs as options, so a library caller gets exactly the run they
-asked for and a test constructing `LintOptions` cannot accidentally pick up a
-file from the working directory.
+everything it needs as options. A library caller gets exactly the run they asked
+for, and a test constructing `LintOptions` cannot accidentally pick up a file
+from the working directory.
 
 Flags beat the file, with one deliberate exception: `--exclude` **accumulates**
 with the configured excludes rather than replacing them. Narrowing a run should
-not quietly discard the repo's standing exclusions, and the alternative — a flag
-that silently re-includes `node_modules` — is a trap.
+not quietly discard the repo's standing exclusions. The alternative is a flag
+that silently re-includes `node_modules`, which is a trap.
 
 Four shapes are rejected rather than defaulted through, each because it silently
 discards an entire configuration:
@@ -78,19 +78,19 @@ discards an entire configuration:
 - **The un-nested config**: keys this tool owns at the top level with no `lint:`.
   The stray keys are named, and the list is derived from the schema's own
   `properties` so it cannot drift from the real key set.
-- **The miscased wrapper**: a top-level key matching `lint` case-insensitively
+- **The miscased wrapper.** A top-level key matches `lint` case-insensitively
   but not exactly. The stray-key check cannot see this one, because its keys are
   nested rather than at the top level.
 - **The un-renamed config**: a `doc-structure-lint.config.yaml` and no
   `moose.config.yaml`. The error names the new filename and the required key.
 - **An unreadable `moose.config.yaml`**: a directory by that name, a permissions
-  error. Only `ENOENT`/`ENOTDIR` counts as absent; anything else is reported
-  rather than defaulted through, and must not reach the legacy check, which
-  would otherwise blame a missing file for a permissions problem.
+  error. Only `ENOENT`/`ENOTDIR` counts as absent, and anything else is reported
+  rather than defaulted through. It must not reach the legacy check, which would
+  otherwise blame a missing file for a permissions problem.
 
 A file that is absent, empty, or that carries only other tools' sections is not
-an error; all defaults apply. That is the case that keeps a shared file usable by
-a project that has not adopted this tool yet — and it is the common case here,
+an error, and all defaults apply. That case keeps a shared file usable by a
+project that has not adopted this tool yet. It is also the common case here,
 since a repo whose pages all declare their `type` needs no config at all.
 
 ### Consequences
@@ -104,26 +104,27 @@ since a repo whose pages all declare their `type` needs no config at all.
 - Good, because `runLint` is unchanged in kind: config supplies values for
   options it already had, so nothing downstream knows config exists.
 - Bad, because the file root is unvalidated by construction. A top-level key that
-  is a genuine misspelling of `lint` — `lnt:`, `linting:` — is indistinguishable
-  from another tool's section and still yields defaults. The two likeliest
-  shapes are covered; a wrapper misspelled any other way is not, and cannot be
-  without a registry of known tool names, which is exactly the coupling this
-  avoids.
-- Bad, because configuration now has two homes — flags and a file — and "why is
+  is a genuine misspelling of `lint`, such as `lnt:` or `linting:`, is
+  indistinguishable from another tool's section and still yields defaults. The
+  two likeliest shapes are covered. A wrapper misspelled any other way is not,
+  and cannot be without a registry of known tool names, which is exactly the
+  coupling this avoids.
+- Bad, because configuration now has two homes, flags and a file, so "why is
   this value not taking effect?" has two places to look. `--explain` answers it
   for template resolution, which is where it matters most.
 - Neutral, because nothing reads `doc-structure-lint.config.yaml`; it is detected
-  only to produce the migration error. Nothing ever wrote one — the pre-rename
-  tool had no config — so this is a courtesy for a file that may not exist.
+  only to produce the migration error. Nothing ever wrote one, because the
+  pre-rename tool had no config, so this is a courtesy for a file that may not
+  exist.
 
 ### Confirmation
 
 `test/unit/config.test.ts` pins the behavior against real files in a temp
-directory rather than a mocked filesystem: the section is read, sibling sections
-are ignored, an absent file and an other-tools-only file both yield defaults, and
-each of the four rejected shapes raises a `MooseLintError` — the unreadable case
-asserting specifically that the legacy file is not blamed for it. Discovery from
-a subdirectory and `-c` on a missing path are covered too.
+directory rather than a mocked filesystem. The section is read and sibling
+sections are ignored. An absent file and an other-tools-only file both yield
+defaults. Each of the four rejected shapes raises a `MooseLintError`, with the
+unreadable case asserting specifically that the legacy file is not blamed for
+it. Discovery from a subdirectory and `-c` on a missing path are covered too.
 
 ## Pros and Cons of the Options
 
@@ -131,7 +132,7 @@ a subdirectory and `-c` on a missing path are covered too.
 
 - Good, because one file is the whole story: no precedence rules between files,
   no second place to look.
-- Good, because tools stay decoupled — a tool needs to know its own key and
+- Good, because tools stay decoupled. A tool needs to know its own key and
   nothing else.
 - Bad, because the file root cannot be strictly validated by any single tool.
 
@@ -147,7 +148,7 @@ a subdirectory and `-c` on a missing path are covered too.
 
 - Good, because it is backward compatible, which would matter if anything had
   ever written a config for this tool.
-- Bad, because two sources for one value need precedence rules, and every "why is
+- Bad, because two sources for one value need precedence rules. Every "why is
   this not taking effect?" then has two files to check rather than one.
 
 ### No configuration; flags only

--- a/adrs/01007-read-settings-from-a-lint-section-of-a-shared-moose-config.md
+++ b/adrs/01007-read-settings-from-a-lint-section-of-a-shared-moose-config.md
@@ -51,7 +51,8 @@ to follow, and what following costs a tool whose config arrives after its CLI.
 The chosen option is **a single `moose.config.yaml`, read under `lint:`.**
 
 The file root is a mapping of tool name to that tool's settings. `loadConfig()`
-reads the file, takes the `lint` value, and hands that to `parseConfig()`.
+reads the file and hands its contents to `parseConfig()`, which takes the
+`lint` value.
 Sibling keys are neither read nor validated. There is no registry of known
 tools, no coordination, and no version coupling between the tools. `src/schemas/config.json`
 describes **the section**, so its strictness applies at every level below `lint:`

--- a/adrs/01007-read-settings-from-a-lint-section-of-a-shared-moose-config.md
+++ b/adrs/01007-read-settings-from-a-lint-section-of-a-shared-moose-config.md
@@ -75,16 +75,16 @@ that silently re-includes `node_modules`, which is a trap.
 Four shapes are rejected rather than defaulted through, each because it silently
 discards an entire configuration:
 
-- **The un-nested config**: keys this tool owns at the top level with no `lint:`.
-  The stray keys are named, and the list is derived from the schema's own
-  `properties` so it cannot drift from the real key set.
+- **The un-nested config.** Keys this tool owns sit at the top level with no
+  `lint:`. The stray keys are named, and the list is derived from the schema's
+  own `properties` so it cannot drift from the real key set.
 - **The miscased wrapper.** A top-level key matches `lint` case-insensitively
   but not exactly. The stray-key check cannot see this one, because its keys are
   nested rather than at the top level.
-- **The un-renamed config**: a `doc-structure-lint.config.yaml` and no
+- **The un-renamed config.** There is a `doc-structure-lint.config.yaml` and no
   `moose.config.yaml`. The error names the new filename and the required key.
-- **An unreadable `moose.config.yaml`**: a directory by that name, a permissions
-  error. Only `ENOENT`/`ENOTDIR` counts as absent, and anything else is reported
+- **An unreadable `moose.config.yaml`.** A directory carries that name, or a
+  permissions error blocks it. Only `ENOENT`/`ENOTDIR` counts as absent, and anything else is reported
   rather than defaulted through. It must not reach the legacy check, which would
   otherwise blame a missing file for a permissions problem.
 

--- a/adrs/01008-gate-on-prose-lint-against-a-pinned-rule-set.md
+++ b/adrs/01008-gate-on-prose-lint-against-a-pinned-rule-set.md
@@ -1,0 +1,139 @@
+---
+status: "accepted"
+date: 2026-09-04
+decision-makers: [hawkeyexl]
+---
+
+# Gate on prose lint, against a pinned rule set
+
+## Context and Problem Statement
+
+[ADR 01003](01003-remove-the-language-model-and-be-deterministic.md) drew the
+family boundary: this tool checks structure and `moose-docevals` judges prose.
+That boundary is about what the tool reports on a user's documents. It says
+nothing about the repo's own writing, which had no check at all.
+
+Adopting the Moose Vale package left 270 alerts across 13 files and a check that
+annotated added lines without failing. An advisory check is a check nobody acts
+on. It also cannot hold a corpus at zero, because nothing stops the next pull
+request from adding the 271st alert.
+
+Making it fail is not one decision but four. Three of them are easy to get
+wrong, in ways that leave a check looking like protection while it enforces
+less than it claims.
+
+## Decision Drivers
+
+- A gate must enforce what its own documentation says it enforces.
+- A gate must never pass by looking at nothing.
+- An external rule set must not be able to redden every open pull request on a
+  day nobody chose.
+- Vendored fixtures must stay byte-for-byte upstream's, whatever the voice says
+  about them.
+
+## Considered Options
+
+- **Gate on every alert, against a pinned package, exempting test input**
+- Keep the check advisory and work the corpus down by habit
+- Gate only on the lines a pull request adds
+- Tune or scope the shared Moose rules instead of rewriting the corpus
+
+## Decision Outcome
+
+The chosen option is to **gate on every alert, against a pinned package**.
+
+**`fail_level: any`, not `fail_on_error: true`.** The action maps
+`fail_on_error` to reviewdog's `-fail-level=error`, which passes the one
+warning-level rule the package ships, `Voices.ColonReveal`. A gate that skips a
+rule its own comment claims to enforce is worse than no gate, because it is
+believed. `fail_level` takes precedence over `fail_on_error`.
+
+**`filter_mode: nofilter`, not `added`.** Whole-corpus checking catches a change
+that breaks the voice in a file it did not touch. An edit to `.vale.ini` or a
+moved pin does exactly that. A run costs well under a second, so the whole
+corpus is affordable on every pull request.
+
+**The package is pinned to a release tag.** Every other external authority here
+is pinned: TGDP at v1.6.0 with `npm run check:tgdp-pin` watching it, the Vale
+binary at 3.20.0, `actions/checkout` at v7. Under an advisory check a floating
+`releases/latest` was absorbed silently. Under a gate it hands a third party the
+power to block merges. It also destroys reproducibility, because re-running
+yesterday's green commit re-fetches today's rules.
+
+**A canary step asserts the rule set is loaded.** Every `BasedOnStyles` lives
+inside the fetched package, so Vale with an empty `StylesPath` lints zero files
+and exits `0`. Only the action's throw on a failed `vale sync` stands between a
+bad fetch and a green run over nothing. That is the failure mode
+[README](../README.md) says the linter itself exits `2` to prevent, so the
+workflow checks `vale ls-config` rather than trusting it.
+
+**Test input is exempted in `.vale.ini`, not in the workflow.** Config is the one
+place both a local `vale .` and CI read, so the two cannot disagree about which
+files are in scope. The globs name the directory (`**/fixtures/**`) rather than
+a path, because Vale matches them against the path as invoked.
+
+The 265 alerts in this repo's own prose were resolved by rewriting it, not by
+loosening the rules. The rules are the house voice, shared across the family.
+Bending them here to fit existing writing would make every sibling repo inherit
+this repo's convenience.
+
+### Consequences
+
+- Good, because the gate now enforces what its documentation says, at every
+  severity and over every file.
+- Good, because moving the pin is a commit with a diff and a review, rather than
+  a surprise on an unrelated pull request.
+- Good, because the canary makes a fetch regression loud instead of green.
+- Bad, because a pinned package goes stale, and nothing yet watches it the way
+  `check:tgdp-pin` watches TGDP. Moving it by hand is the cost until something
+  does.
+- Bad, because MADR's `Chosen option:` lead-in trips `Voices.ColonReveal`, so
+  all seven earlier records were reworded to "The chosen option is". A carve-out
+  would have hidden genuine colon-reveals in the same files.
+- Neutral, because `reporter: github-pr-review` cannot attach comments outside
+  the diff. reviewdog falls back to Check annotations there, so nothing is lost,
+  but out-of-diff findings arrive as annotations rather than review comments.
+
+### Confirmation
+
+`.github/workflows/vale.yml` carries the gate, and reversing any part of it
+fails visibly:
+
+- Drop `fail_level: any` back to `fail_on_error: true` and a `Voices.ColonReveal`
+  alert stops failing the check.
+- Drop `filter_mode: nofilter` back to `added` and an alert in an untouched file
+  stops failing the check.
+- Float the pin back to `releases/latest` and the corpus is no longer checked
+  against a known rule set.
+- Break the package fetch and the canary step fails rather than the job passing
+  over zero rules.
+
+`vale .` from the repository root reports zero alerts. It reports the same zero
+from an absolute path and from inside `test/`, which is what the `**/` glob
+prefixes buy.
+
+## Pros and Cons of the Options
+
+### Keep the check advisory and work the corpus down by habit
+
+- Good, because no upstream release can ever block a merge.
+- Good, because it needs no decision about severity, pinning, or scope.
+- Bad, because the corpus drifts back the first time somebody is in a hurry, and
+  270 alerts is the evidence that it does.
+
+### Gate only on the lines a pull request adds
+
+- Good, because a contributor is only ever asked about prose they wrote.
+- Good, because reviewdog can always annotate those lines inline.
+- Bad, because an edit to `.vale.ini` or a moved pin breaks files nobody
+  touched, and the check stays green.
+
+### Tune or scope the shared Moose rules instead of rewriting the corpus
+
+- Good, because 126 em-dash alerts are real evidence about a rule. The rule's
+  own header documents an escape hatch for exactly that argument.
+- Good, because it would have kept MADR's `Chosen option:` label intact.
+- Bad, because the rules are shared across the family, so tuning them to fit one
+  repo's existing prose exports that convenience to every sibling. If a rule is
+  wrong it should be argued upstream in `moose-vale`, on its merits, not bent
+  here under deadline.

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -17,6 +17,7 @@ and a record disagree, the code is what runs and the record needs fixing.
 | [01005](01005-ship-tgdp-structure-templates-without-demoting-user-templates.md) | Ship TGDP structure templates as built-ins, without demoting user templates |
 | [01006](01006-take-the-h1-from-frontmatter-when-the-body-has-none.md) | Take the H1 from frontmatter when the body has none |
 | [01007](01007-read-settings-from-a-lint-section-of-a-shared-moose-config.md) | Read settings from a `lint:` section of a shared `moose.config.yaml` |
+| [01008](01008-gate-on-prose-lint-against-a-pinned-rule-set.md) | Gate on prose lint, against a pinned rule set |
 
 ## Writing one
 

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -1,8 +1,8 @@
 # Architecture decisions
 
 Why `moose-lint` is built the way it is. Each record states the problem, the
-options that were actually considered, what was chosen, and — the part worth
-reading — what it costs.
+options that were actually considered, and what was chosen. Then it states what
+the choice costs, which is the part worth reading.
 
 These are a log, not a specification. A record describes the decision as it was
 made; where later work changed something, the later record says so. If the code
@@ -20,13 +20,13 @@ and a record disagree, the code is what runs and the record needs fixing.
 
 ## Writing one
 
-Follow the format of the existing records — frontmatter (`status`, `date`,
-`decision-makers`), then Context and Problem Statement, Decision Drivers,
-Considered Options, Decision Outcome, Consequences, Confirmation, and Pros and
-Cons of the Options.
+Follow the format of the existing records. They open with frontmatter
+(`status`, `date`, `decision-makers`). Then come Context and Problem Statement,
+Decision Drivers, Considered Options, Decision Outcome, Consequences,
+Confirmation, and Pros and Cons of the Options.
 
 Two things make a record worth having. **Name the options you rejected**, and
 say what was good about them; a record listing only the winner is an
 advertisement. And **write the Confirmation section**, naming the tests that
-would fail if the decision were reversed — a decision nothing checks is a
+would fail if the decision were reversed. A decision nothing checks is a
 preference.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "lint:prose": "vale sync && vale .",
     "commitlint": "commitlint --edit",
     "semantic-release": "semantic-release",
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "lint:prose": "vale sync && vale .",
+    "lint:prose": "node scripts/lint-prose.mjs",
     "commitlint": "commitlint --edit",
     "semantic-release": "semantic-release",
     "prepare": "husky",

--- a/scripts/lint-prose.mjs
+++ b/scripts/lint-prose.mjs
@@ -1,0 +1,73 @@
+/**
+ * Lint this repo's prose against the house voice, the way CI does.
+ *
+ * `vale` alone cannot back this check: its exit status is non-zero for
+ * error-level alerts only, and the Moose package ships one warning-level rule
+ * (`Voices.ColonReveal`). CI gates with reviewdog's `-fail-level=any`, so a
+ * bare `vale .` would pass locally what the gate fails — the divergence a
+ * single source of truth is supposed to prevent. This reads the JSON output
+ * and fails on any alert at any severity.
+ *
+ *   npm run lint:prose          sync the package, then lint
+ *   npm run lint:prose -- --no-sync   skip the fetch, for offline runs
+ *
+ * Exit status is set via `process.exitCode` rather than `process.exit()`, to
+ * match the repo's other scripts and let stdout flush.
+ */
+import { spawnSync } from "node:child_process";
+
+const sync = !process.argv.includes("--no-sync");
+
+function vale(args) {
+  const r = spawnSync("vale", args, { encoding: "utf8" });
+  if (r.error?.code === "ENOENT") {
+    console.error(
+      "vale is not on your PATH. Install it from https://vale.sh/docs/install",
+    );
+    process.exitCode = 2;
+    return null;
+  }
+  return r;
+}
+
+if (sync) {
+  const r = vale(["sync"]);
+  if (!r) process.exit();
+  if (r.status !== 0) {
+    console.error(r.stderr || r.stdout);
+    console.error("vale sync failed; the rule set is not available.");
+    process.exitCode = 2;
+    process.exit();
+  }
+}
+
+const run = vale(["--output=JSON", "."]);
+if (!run) process.exit();
+
+// Vale exits 2 on a configuration error and prints a message, not JSON.
+let byFile;
+try {
+  byFile = JSON.parse(run.stdout);
+} catch {
+  console.error(run.stdout || run.stderr);
+  process.exitCode = 2;
+  process.exit();
+}
+
+const alerts = Object.entries(byFile).flatMap(([file, list]) =>
+  list.map((a) => ({ file, ...a })),
+);
+
+if (alerts.length === 0) {
+  console.log("✔ 0 alerts");
+  process.exit();
+}
+
+for (const a of alerts) {
+  console.log(
+    `${a.file}:${a.Line}:${a.Span?.[0] ?? 1}  ${a.Severity}  ${a.Check}  ${a.Message}`,
+  );
+}
+const files = new Set(alerts.map((a) => a.file)).size;
+console.log(`\n✗ ${alerts.length} alert(s) in ${files} file(s)`);
+process.exitCode = 1;


### PR DESCRIPTION
## Summary

Follow-up to #23, which left the backlog explicit: *"270 alerts across 13 files … the backlog can be worked down before `fail_on_error` is flipped."* This works it down and gates on it.

- **Prose.** README, CLAUDE.md, and all eight ADR files rewritten to zero alerts. Em dashes resolved by restructuring sentences rather than swapping punctuation, as `Moose.EmDash` asks; long sentences split, or turned into the lists several were already imitating with semicolons.
- **Gate.** `filter_mode: nofilter` + `fail_level: any`, a canary step, and a pinned rule set — see below.
- **Scope.** `**/fixtures/**` and `**/artifacts/**` exempted in `.vale.ini`.
- **Local.** `npm run lint:prose` runs the identical check.
- **Record.** [ADR 01008](adrs/01008-gate-on-prose-lint-against-a-pinned-rule-set.md).

| | before | after |
| --- | --- | --- |
| alerts | 270 | **0** |
| files | 13 | 0 |

Before, by rule: `Direct.Length` 131, `Moose.EmDash` 126, `Voices.ColonReveal` 12, `Voices.Banned` 1.

## Corrections to the first version of this PR

Review found the gate weaker than my own comments claimed. Two of these were my errors, verified against Vale 3.20.0 and the action's source:

**`fail_on_error: true` did not mean "any alert".** It maps to reviewdog's `-fail-level=error`, which passes the one warning-level rule the package ships (`Voices.ColonReveal`). A colon-reveal line in the README got annotated and the check went **green**. Now `fail_level: any`, which takes precedence over `fail_on_error` — so the claim is true.

**"An unsynced package is a hard Vale error" was over-broad.** I tested only a *missing* `StylesPath` (E201, exit 2). But every `BasedOnStyles` lives inside the package, so a `StylesPath` that exists without `.vale-config/` makes Vale lint **zero files and exit 0** — green over nothing. Only the action's throw on a failed `vale sync` prevented it. The job now asserts the rule set is loaded via `vale ls-config`.

**The exemption globs were invocation-relative.** Vale matches globs against the path as invoked, so `test/fixtures/**` exempted nothing under an absolute path or from inside `test/` — what editor plugins and language servers pass. Both reported 5 alerts on vendored TGDP fixtures that CLAUDE.md forbids editing. Now `**/fixtures/**`, which also covers a future `test/e2e/fixtures/`.

| invocation | before | after |
| --- | --- | --- |
| `vale .` | 0 | 0 |
| `vale /abs/path` | 5 | 0 |
| `cd test && vale .` | 5 | 0 |

**The package was unpinned.** `releases/latest` under a hard gate lets a third party redden every open PR, and destroys reproducibility — re-running yesterday's green commit refetches today's rules. Pinned to `v0.3.3`; everything else here is already pinned.

**`npm run lint:prose` could pass what CI failed.** Vale's exit status covers error-level alerts only. It's now `scripts/lint-prose.mjs`, which reads the JSON and fails on any alert — the parity the workflow comment claims.

Also: `paths:` gained `**.txt` (the package styles it) and this workflow itself, so a change to the gate runs the gate; plus a concurrency group matching `claude-pr-review.yml`.

## ADR passages restored

The prose pass changed what three accepted records said. Restored:

- **01001** — "mirroring `docmeta`'s registry … **over** an interface shaped like its `MetadataExtractor`" (built *on top of*) had become "That was **chosen over**" (rejected). `src/types.ts:121` says the interface *is* "Shaped after docmeta's `MetadataExtractor`", and the Considered Options list never mentions such an alternative.
- **01003** — splitting off the appositive left "two tools both making AI judgments is strictly worse" unqualified, condemning `moose-docevals` and `moose-tracevals`, which the same paragraph names as legitimate.
- **01002** and **01006** — normative "when P and Q, do R" had become "P may happen while Q. Then R.", losing which clauses are required. Both are explicit lists now.
- **01007** — the four-shape list is parallel again.

## Verification

- `npm run lint:prose` — 0 alerts; **exits 1** on a warning-only alert (the bug above)
- `vale .` clean from repo root, an absolute path, and inside `test/`
- `npm run typecheck` clean · `npm test` 513 passed · `npm run smoke` passed
- 23 relative links in changed files resolve; `vale.yml` and `package.json` parse

## Known limitations

- `cd test/fixtures && vale .` still lints the fixtures — no path component identifies the directory, so no glob can express it. Lint from the repo root.
- Nothing yet watches the Vale pin the way `check:tgdp-pin` watches TGDP. Moving it is manual; noted in 01008's Consequences.

## Docs impact

CLAUDE.md and README gain a note on the prose lint, how to run it, and why the pin exists. No user-facing behavior change, no `src/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C76D6H2P44HHDLLqjq53z5
